### PR TITLE
Add ccTLDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Data sources below for further information):
 31. [IEA](https://www.iea.org/countries) (World Energy Balances 2021)
 32. [DACcode](https://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/dacandcrscodelists.htm)
     (numeric - OECD Development Assistance Committee)
+33. [ccTLD](https://www.iana.org/domains/root/db)
 
 Coco contains official recognised codes as well as non-standard codes
 for disputed or dissolved countries. To restrict the set to only the

--- a/country_converter/country_data.tsv
+++ b/country_converter/country_data.tsv
@@ -1,257 +1,257 @@
-name_short	name_official	regex	ISO2	ISO3	ISOnumeric	UNcode	FAOcode	GBDcode	continent	UNregion	EXIO1	EXIO2	EXIO3	EXIO1_3L	EXIO2_3L	EXIO3_3L	WIOD	Eora	MESSAGE	IMAGE	REMIND	OECD	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	EURO	UN	UNmember	obsolete	Cecilia2050	BRIC	APEC	BASIC	CIS	G7	G20	IEA	DACcode
-Afghanistan	Islamic Republic of Afghanistan	afghan	AF	AFG	4	4	2	160	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	AFG	SAS	Rest of South Asia	OAS												1946	1946		RoW							Other non-OECD Asia	625
-Aland Islands	Åland Islands	\b(a|å)land	AX	ALA	248	248	284		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ALA			EUR															RoW								
-Albania	Republic of Albania	albania	AL	ALB	8	8	3	43	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ALB	EEU	Central Europe	NEU												1955	1955		RoW							Albania	71
-Algeria	People's Democratic Republic of Algeria	algeria	DZ	DZA	12	12	4	139	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	DZA	MEA	Northern Africa	MEA												1962	1962		RoW							Algeria	130
-American Samoa	American Samoa	^(?=.*americ).*samoa	AS	ASM	16	16	5	298	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	ASM	PAS	Oceania	OAS															RoW							Other non-OECD Asia	880
-Andorra	Principality of Andorra	andorra	AD	AND	20	20	6	74	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	AND	WEU	Western Europe	NEU												1993	1993		RoW								
-Angola	Republic of Angola	angola	AO	AGO	24	24	7	168	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	AGO	AFR	Rest of Southern Africa	SSA												1976	1976		RoW							Angola	225
-Anguilla	Anguilla	anguill?a	AI	AIA	660	660	258		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	AIA		Central America	LAM															RoW							Other non-OECD Americas	
-Antarctica	Antarctica	antarctica	AQ	ATA	10	10	30		Antarctica	Antarctica	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	
-Antigua and Barbuda	Antigua and Barbuda	antigua	AG	ATG	28	28	8	105	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ATG	LAC		LAM												1981	1981		RoW							Other non-OECD Americas	377
-Argentina	Argentine Republic	argentin	AR	ARG	32	32	9	97	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	ARG	LAC	Rest of South America	LAM												1945	1945		RoW						G20	Argentina	425
-Armenia	Republic of Armenia	armenia	AM	ARM	51	51	1	33	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	ARM	FSU	Russia region	REF												1992	1992		RoW				CIS			Armenia	610
-Aruba	Aruba	^(?!.*bonaire).*\baruba	AW	ABW	533	533	22		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ABW		Central America	LAM															RoW							Other non-OECD Americas	
-Australia	Commonwealth of Australia	australia	AU	AUS	36	36	10	71	Oceania	Australia and New Zealand	AU	AU	AU	AUS	AUS	AUS	AUS	AUS	PAO	Oceania	CAZ	1971											1945	1945		HI		APEC				G20	Australia	801
-Austria	Republic of Austria	austria	AT	AUT	40	40	11	75	Europe	Western Europe	AT	AT	AT	AUT	AUT	AUT	AUT	AUT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Austria	1
-Azerbaijan	Republic of Azerbaijan	azerbaijan	AZ	AZE	31	31	52	34	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	AZE	FSU	Russia region	REF												1992	1992		RoW				CIS			Azerbaijan	611
-Bahamas	Commonwealth of the Bahamas	bahamas	BS	BHS	44	44	12	106	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	BHS	LAC	Central America	LAM												1973	1973		RoW							Other non-OECD Americas	
-Bahrain	Kingdom of Bahrain	bahrain	BH	BHR	48	48	13	140	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	BHR	MEA	Middle East	MEA												1971	1971		RoW							Bahrain	
-Bangladesh	People's Republic of Bangladesh	bangladesh|^(?=.*east).*paki?stan	BD	BGD	50	50	16	161	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BGD	SAS	Rest of South Asia	OAS												1974	1974		RoW							Bangladesh	666
-Barbados	Barbados	barbados	BB	BRB	52	52	14	107	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	BRB	LAC	Central America	LAM												1966	1966		RoW							Other non-OECD Americas	
-Belarus	Republic of Belarus	belarus|byelo	BY	BLR	112	112	57	57	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	BLR	FSU	Ukraine region	REF												1945	1945		RoW				CIS			Belarus	86
-Belgium	Kingdom of Belgium	^(?!.*luxem).*belgium	BE	BEL	56	56	255	76	Europe	Western Europe	BE	BE	BE	BEL	BEL	BEL	BEL	BEL	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Belgium	2
-Belize	Belize	belize|^(?=.*british).*honduras	BZ	BLZ	84	84	23	108	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	BLZ	LAC	Central America	LAM												1981	1981		RoW							Other non-OECD Americas	352
-Benin	Republic of Benin	benin|dahome	BJ	BEN	204	204	53	200	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BEN	AFR	Western Africa	SSA												1960	1960		RoW							Benin	236
-Bermuda	Bermuda	bermuda	BM	BMU	60	60	17	305	America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	BMU	LAC	Central America	LAM															RoW							Other non-OECD Americas	
-Bhutan	Kingdom of Bhutan	bhutan	BT	BTN	64	64	18	162	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BTN	SAS	Rest of South Asia	OAS												1971	1971		RoW							Other non-OECD Asia	630
-Bolivia	Plurinational State of Bolivia	bolivia	BO	BOL	68	68	19	121	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	BOL	LAC	Rest of South America	LAM												1945	1945		RoW							Plurinational State of Bolivia	428
-"Bonaire, Saint Eustatius and Saba"	"Bonaire, Saint Eustatius and Saba"	^(?=.*bonaire).*eustatius|^(?=.*carib).*netherlands|\bbes.?islands	BQ	BES	535	535	278		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas	
-Bosnia and Herzegovina	Bosnia and Herzegovina	herzegovina|bosnia	BA	BIH	70	70	80	44	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	BIH	EEU	Central Europe	NEU												1992	1992		RoW							Bosnia and Herzegovina	64
-Botswana	Republic of Botswana	botswana|bechuana	BW	BWA	72	72	20	193	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BWA	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Botswana	227
-Bouvet Island	Bouvet Island	bouvet	BV	BVT	74	74	31		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	
-Brazil	Federative Republic of Brazil	brazil	BR	BRA	76	76	21	135	America	South America	BR	BR	BR	BRA	BRA	BRA	BRA	BRA	LAC	Brazil	LAM												1945	1945		BX	BRIC		BASIC			G20	Brazil	431
-British Antarctic Territories	British Antarctic Territories	br.*antarctic.?territ.*	B1	BA1					Antarctica		WW	WA	WA	WWW	WWA	WWA	RoW																		1979	RoW								
-British Indian Ocean Territory	British Indian Ocean Territory	br.*indian.?ocean	IO	IOT	86	86	24		Africa	Eastern Africa	WW	WA	WA	WWW	WWA	WWA	RoW		AFR		OAS															RoW							Other non-OECD Asia	
-British Virgin Islands	British Virgin Islands	^(?=.*\bu\.?\s?k).*virgin|^(?=.*br.*).*virgin|^(?=.*kingdom).*virgin|BVI	VG	VGB	92	92	239		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VGB		Central America	LAM															RoW							Other non-OECD Americas	
-Brunei Darussalam	"Nation of Brunei, Abode of Peace"	brunei	BN	BRN	96	96	26	66	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BRN	PAS	Southeastern Asia	OAS												1984	1984		RoW		APEC					Brunei Darussalam	
-Bulgaria	Republic of Bulgaria	bulgaria	BG	BGR	100	100	27	45	Europe	Eastern Europe	BG	BG	BG	BGR	BGR	BGR	BGR	BGR	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Bulgaria	72
-Burkina Faso	Burkina Faso	burkina|\bfaso|upper.?volta	BF	BFA	854	854	233	201	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BFA	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	287
-Burundi	Republic of Burundi	burundi	BI	BDI	108	108	29	175	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BDI	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	228
-Cabo Verde	Republic of Cabo Verde	(cabo|cape) *verde	CV	CPV	132	132	35	203	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CPV	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	230
-Cambodia	Kingdom of Cambodia	cambodia|kampuchea|khmer|^p\.?r\.?k\.?$	KH	KHM	116	116	115	10	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KHM	CPA	Southeastern Asia	OAS												1955	1955		RoW							Cambodia	728
-Cameroon	Republic of Cameroon	cameroon	CM	CMR	120	120	32	202	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CMR	AFR	Western Africa	SSA												1960	1960		RoW							Cameroon	229
-Canada	Canada	canada	CA	CAN	124	124	33	101	America	Northern America	CA	CA	CA	CAN	CAN	CAN	CAN	CAN	NAM	Canada	CAZ	1961											1945	1945		HI		APEC			G7	G20	Canada	301
-Cayman Islands	Cayman Islands	cayman	KY	CYM	136	136	36		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CYM		Central America	LAM															RoW							Other non-OECD Americas	
-Central African Republic	Central African Republic	central.?african.?rep.*	CF	CAF	140	140	37	169	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CAF	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	231
-Chad	Republic of Chad	\bchad	TD	TCD	148	148	39	204	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TCD	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	232
-Channel Islands	Channel Islands	channel.?island.*		CHI	830	830	259		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW		WEU											EEA					2006	RoW								
-Chile	Republic of Chile	\bchile	CL	CHL	152	152	40	98	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	CHL	LAC	Rest of South America	LAM	2010											1945	1945		RoW		APEC					Chile	
-China	People's Republic of China	^(?!repub)(?!taiwan)(?!hong.*kong)(?!macao).*china(?!.*hong.*kong)(?!.*macao)|^PRC$	CN	CHN	156	156	351	6	Asia	Eastern Asia	CN	CN	CN	CHN	CHN	CHN	CHN	CHN	CPA	China region	CHA												1945	1945		BX	BRIC	APEC	BASIC			G20	People's Republic of China	730
-Christmas Island	Christmas Island	christmas	CX	CXR	162	162	42		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia	
-Cocos (Keeling) Islands	Territory of the Cocos (Keeling) Islands	\bcocos|keeling	CC	CCK	166	166	43		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia	
-Colombia	Republic of Colombia	colombia	CO	COL	170	170	44	125	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	COL	LAC	Rest of South America	LAM	2020											1945	1945		RoW							Colombia	437
-Comoros	Union of the Comoros	comoro	KM	COM	174	174	45	176	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COM	AFR	Eastern Africa	SSA												1975	1975		RoW							Other Africa	233
-Congo Republic	Republic of the Congo	"^(?!.*\bdem)(?!.*\bdr)(?!.*kinshasa)(?!.*zaire)(?!.*belg)(?!.*l\w{1,2}opoldville)(?!.*free)(^rep.*).*\bcongo.*(?!.*\bdem)(?!.*\bdr).*|\bwest.*congo|^congo[,;\s]*(?!.*dem)rep.*?$|^congo$|\bcongo.*brazza.*"	CG	COG	178	178	46	170	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COG	AFR	Western Africa	SSA												1960	1960		RoW							Republic of the Congo	234
-Cook Islands	Cook Islands	\bcook	CK	COK	184	184	47	320	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	COK		Oceania	OAS															RoW							Other non-OECD Asia	
-Costa Rica	Republic of Costa Rica	costa.?rica	CR	CRI	188	188	48	126	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	CRI	LAC	Central America	LAM												1945	1945		RoW							Costa Rica	336
-Cote d'Ivoire	Republic of Côte d'Ivoire	.*(ivoire|ivory)	CI	CIV	384	384	107	205	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CIV	AFR	Western Africa	SSA												1960	1960		RoW							Côte d'Ivoire	247
-Croatia	Republic of Croatia	croatia|hrvatska	HR	HRV	191	191	98	46	Europe	Southern Europe	WW	WE	HR	WWW	WWE	HRV	RoW	HRV	EEU	Central Europe	EUR		EU	EU28	EU27					EEA			1992	1992		RoW						G20	Croatia	62
-Cuba	Republic of Cuba	\bcuba	CU	CUB	192	192	49	109	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CUB	LAC		LAM												1945	1945		RoW							Cuba	338
-Curacao	Country of Curaçao	\bcura(c|ç)ao	CW	CUW	531	531	279		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Curaçao/Netherlands Antilles	
-Cyprus	Republic of Cyprus	cyprus	CY	CYP	196	196	50	77	Asia	Western Asia	CY	CY	CY	CYP	CYP	CYP	CYP	CYP	WEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA		2008	1960	1960		EU						G20	Cyprus	30
-Czech Republic	Czech Republic	^(?=.*rep).*czech.*|czechia|bohemia|.*czech.*	CZ	CZE	203	203	167	47	Europe	Eastern Europe	CZ	CZ	CZ	CZE	CZE	CZE	CZE	CZE	EEU	Central Europe	EUR	1995	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1993	1993		EU						G20	Czech Republic	68
-Denmark	Kingdom of Denmark	denmark	DK	DNK	208	208	54	78	Europe	Northern Europe	DK	DK	DK	DNK	DNK	DNK	DNK	DNK	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen		1945	1945		EU						G20	Denmark	3
-Djibouti	Republic of Djibouti	djibouti	DJ	DJI	262	262	72	177	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	DJI	AFR	Eastern Africa	SSA												1977	1977		RoW							Other Africa	274
-Dominica	Commonwealth of Dominica	dominica(?!n)	DM	DMA	212	212	55	110	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	DMA	LAC	Central America	LAM												1978	1978		RoW							Other non-OECD Americas	378
-Dominican Republic	Dominican Republic	dominican	DO	DOM	214	214	56	111	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	DOM	LAC	Central America	LAM												1945	1945		RoW							Dominican Republic	340
-DR Congo	Democratic Republic of the Congo	"\bdem.*congo|congo.*\bdem|congo.*\bdr|\bdr.*congo|\bd\.?r\.?c|\bd\.?r\.?o\.?c|\br\.?d\.?c|belgian.?congo|congo.?free.?state|kinshasa|zaire|l\w{1,2}opoldville|^the\ congo$|^RDC$|^DROC$|\bcongo.*dem.*"	CD	COD	180	180	250	171	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COD	AFR	Western Africa	SSA												1960	1960		RoW							Democratic Republic of the Congo	235
-Ecuador	Republic of Ecuador	ecuador	EC	ECU	218	218	58	122	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	ECU	LAC	Rest of South America	LAM												1945	1945		RoW							Ecuador	440
-Egypt	Arab Republic of Egypt	egypt	EG	EGY	818	818	59	141	Africa	Northern Africa	WW	WM	WM	WWW	WWM	WWM	RoW	EGY	MEA	Northern Africa	MEA												1945	1945		RoW							Egypt	142
-El Salvador	Republic of El Salvador	el.?salvador	SV	SLV	222	222	60	127	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	SLV	LAC	Central America	LAM												1945	1945		RoW							El Salvador	342
-Equatorial Guinea	Republic of Equatorial Guinea	guine.*eq|eq.*guine|^(?=.*span).*guinea	GQ	GNQ	226	226	61	172	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GNQ	AFR	Western Africa	SSA												1968	1968		RoW							Equatorial Guinea	245
-Eritrea	State of Eritrea	eritrea	ER	ERI	232	232	178	178	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ERI	AFR	Eastern Africa	SSA												1993	1993		RoW							Eritrea	271
-Estonia	Republic of Estonia	estonia	EE	EST	233	233	63	58	Europe	Northern Europe	EE	EE	EE	EST	EST	EST	EST	EST	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2011	1991	1991		EU						G20	Estonia	82
-Eswatini	Kingdom of Eswatini	swaziland|eswatini	SZ	SWZ	748	748	209	197	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SWZ	AFR	Rest of Southern Africa	SSA												1968	1968		RoW							Other Africa	280
-Ethiopia	Federal Democratic Republic of Ethiopia	ethiopia|abyssinia	ET	ETH	231	231	238	179	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ETH	AFR	Eastern Africa	SSA												1945	1945		RoW							Ethiopia	238
-Faeroe Islands	Faeroe Islands	faroe|faeroe	FO	FRO	234	234	64		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	FRO	WEU	Western Europe	EUR										Schengen					RoW								
-Falkland Islands	Falkland Islands (Malvinas)	falkland|malvinas	FK	FLK	238	238	65		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	FLK		Rest of South America	LAM															RoW							Other non-OECD Americas	
-Fiji	Republic of Fiji	fiji	FJ	FJI	242	242	66	22	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	FJI	PAS	Oceania	OAS												1970	1970		RoW							Other non-OECD Asia	832
-Finland	Republic of Finland	finland	FI	FIN	246	246	67	79	Europe	Northern Europe	FI	FI	FI	FIN	FIN	FIN	FIN	FIN	WEU	Western Europe	EUR	1969	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Finland	18
-France	French Republic	^(?!.*\bdep).*france|french.?republic|\bgaul	FR	FRA	250	250	68	80	Europe	Western Europe	FR	FR	FR	FRA	FRA	FRA	FRA	FRA	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU					G7	G20	France	4
-French Guiana	Guiana	^(?=.*french).*guiana|guiana	GF	GUF	254	254	69		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	GUF	LAC	Rest of South America	LAM															RoW							Other non-OECD Americas	
-French Polynesia	French Polynesia	french.?polynesia	PF	PYF	258	258	70		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PYF	PAS	Oceania	OAS															RoW							Other non-OECD Asia	
-French Southern Territories	Territory of the French Southern and Antarctic Lands	french.?southern|\bfr.*\bso.*\ban.*\b\bt	TF	ATF	260	260	71		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW				OAS															RoW							Other Africa	
-Gabon	Gabonese Republic	gabon	GA	GAB	266	266	74	173	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GAB	AFR	Western Africa	SSA												1960	1960		RoW							Gabon	239
-Gambia	Republic of the Gambia	gambia	GM	GMB	270	270	75	206	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GMB	AFR	Western Africa	SSA												1965	1965		RoW							Other Africa	240
-Georgia	Georgia	^(?!.*south).*georgia(?!.*US.*)	GE	GEO	268	268	73	35	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	GEO	FSU	Russia region	REF												1992	1992		RoW							Georgia	612
-Germany	Federal Republic of Germany	"^(?!e|w)(fed)?.*germany(?!,? *e|,? *w)(,? *)(\bfed)?"	DE	DEU	276	276	79	81	Europe	Western Europe	DE	DE	DE	DEU	DEU	DEU	DEU	DEU	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1973	1973		EU					G7	G20	Germany	5
-Ghana	Republic of Ghana	ghana|gold.?coast	GH	GHA	288	288	81	207	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GHA	AFR	Western Africa	SSA												1957	1957		RoW							Ghana	241
-Gibraltar	Gibraltar	gibraltar	GI	GIB	292	292	82		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	GIB	WEU	Western Europe	EUR									EEA						RoW							Gibraltar	
-Greece	Hellenic Republic	greece|hellenic|hellas	GR	GRC	300	300	84	82	Europe	Southern Europe	GR	GR	GR	GRC	GRC	GRC	GRC	GRC	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	2001	1945	1945		EU						G20	Greece	40
-Greenland	Greenland	greenland	GL	GRL	304	304	85	349	America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	GRL	WEU		NEU										Schengen					RoW							Other non-OECD Americas	
-Grenada	Grenada	grenada	GD	GRD	308	308	86	112	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	GRD	LAC	Central America	LAM												1974	1974		RoW							Other non-OECD Americas	381
-Guadeloupe	Guadeloupe	guadeloupe	GP	GLP	312	312	87		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	GLP	LAC	Central America	LAM															RoW							Other non-OECD Americas	
-Guam	Guam	\bguam	GU	GUM	316	316	88	351	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	GUM	NAM		OAS															RoW							Other non-OECD Asia	
-Guatemala	Republic of Guatemala	guatemala	GT	GTM	320	320	89	128	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	GTM	LAC	Central America	LAM												1945	1945		RoW							Guatemala	347
-Guernsey	Guernsey	guernsey	GG	GGY	831	831			Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	GGY			EUR									EEA						RoW								
-Guinea	Republic of Guinea	^(?!.*eq)(?!.*span)(?!.*bissau)(?!.*pap)(?!.*new)(?!p.*n.*).*guinea	GN	GIN	324	324	90	208	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GIN	AFR	Western Africa	SSA												1958	1958		RoW							Other Africa	243
-Guinea-Bissau	Republic of Guinea-Bissau	^(.*portu).*guinea|guinea.*bissau	GW	GNB	624	624	175	209	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GNB	AFR	Western Africa	SSA												1974	1974		RoW							Other Africa	244
-Guyana	Co-operative Republic of Guyana	guyana|british.?guiana	GY	GUY	328	328	91	113	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	GUY	LAC	Rest of South America	LAM												1966	1966		RoW							Guyana	446
-Haiti	Republic of Haiti	(ha(i|\xef|\xc3\xaf)ti)	HT	HTI	332	332	93	114	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	HTI	LAC	Central America	LAM												1945	1945		RoW							Haiti	349
-Heard and McDonald Islands	Territory of Heard Island and McDonald Islands	heard.*mc.*donald	HM	HMD	334	334	92		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				CAZ															RoW							Other non-OECD Asia	
-Honduras	Republic of Honduras	^(?!.*brit).*honduras	HN	HND	340	340	95	129	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	HND	LAC	Central America	LAM												1945	1945		RoW							Honduras	351
-Hong Kong	Hong Kong SAR	.*hong.*kong|hksar	HK	HKG	344	344	96		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	HKG	CPA	China region	CHA															RoW		APEC					Hong Kong (China)	
-Hungary	Republic of Hungary	hungary	HU	HUN	348	348	97	48	Europe	Eastern Europe	HU	HU	HU	HUN	HUN	HUN	HUN	HUN	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1955	1955		EU						G20	Hungary	75
-Iceland	Republic of Iceland	iceland	IS	ISL	352	352	99	83	Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ISL	WEU	Western Europe	NEU	1961								EEA	Schengen		1946	1946		RoW							Iceland	20
-India	Republic of India	^(?!\D*(?:bassas))\D*india(?!.*ocea)(?!na)	IN	IND	356	356	100	163	Asia	Southern Asia	IN	IN	IN	IND	IND	IND	IND	IND	SAS	India	IND												1945	1945		BX	BRIC		BASIC			G20	India	645
-Indonesia	Republic of Indonesia	indonesia	ID	IDN	360	360	101	11	Asia	South-Eastern Asia	ID	ID	ID	IDN	IDN	IDN	IDN	IDN	PAS	Indonesia region	OAS												1950	1950		BX		APEC				G20	Indonesia	738
-Iran	Islamic Republic of Iran	\biran|persia	IR	IRN	364	364	102	142	Asia	Southern Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRN	MEA	Middle East	MEA												1945	1945		RoW							Islamic Republic of Iran	540
-Iraq	Republic of Iraq	\biraq|mesopotamia	IQ	IRQ	368	368	103	143	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRQ	MEA	Middle East	MEA												1945	1945		RoW							Iraq	543
-Ireland	Ireland	^(?!.*north.*).*ireland	IE	IRL	372	372	104	84	Europe	Northern Europe	IE	IE	IE	IRL	IRL	IRL	IRL	IRL	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA		1999	1955	1955		EU						G20	Ireland	21
-Isle of Man	Isle of Man	^(?=.*isle).*\bman	IM	IMN	833	833	264		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	IMN	WEU		EUR									EEA						RoW								
-Israel	State of Israel	israel	IL	ISR	376	376	105	85	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	ISR	MEA	Middle East	MEA	2010											1949	1949		RoW							Israel	546
-Italy	Italian Republic	.*italy|.*italia.*	IT	ITA	380	380	106	86	Europe	Southern Europe	IT	IT	IT	ITA	ITA	ITA	ITA	ITA	WEU	Western Europe	EUR	1962	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU					G7	G20	Italy	6
-Jamaica	Jamaica	jamaica	JM	JAM	388	388	109	115	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	JAM	LAC	Central America	LAM												1962	1962		RoW							Jamaica	354
-Japan	Japan	japan	JP	JPN	392	392	110	67	Asia	Eastern Asia	JP	JP	JP	JPN	JPN	JPN	JPN	JPN	PAO	Japan	JPN	1964											1956	1956		HI		APEC			G7	G20	Japan	701
-Jersey	Jersey	^(?!.*new).*jersey	JE	JEY	832	832	283		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	JEY			EUR									EEA						RoW								
-Jordan	Hashemite Kingdom of Jordan	jordan	JO	JOR	400	400	112	144	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	JOR	MEA	Middle East	MEA												1955	1955		RoW							Jordan	549
-Kazakhstan	Republic of Kazakhstan	kazak	KZ	KAZ	398	398	108	36	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KAZ	FSU	Central Asia	REF												1992	1992		RoW				CIS			Kazakhstan	613
-Kenya	Republic of Kenya	kenya|british.?east.?africa|east.?africa.?prot	KE	KEN	404	404	114	180	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	KEN	AFR	Eastern Africa	SSA												1963	1963		RoW							Kenya	248
-Kiribati	Republic of Kiribati	kiribati	KI	KIR	296	296	83	23	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	KIR	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	836
-Kosovo	Republic of Kosovo	kosovo	XK	XKX					Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	KSV																		RoW							Kosovo	57
-Kuwait	State of Kuwait	kuwait	KW	KWT	414	414	118	145	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	KWT	MEA	Middle East	MEA												1963	1963		RoW							Kuwait	552
-Kyrgyz Republic	Kyrgyz Republic	kyrgyz|kirghiz	KG	KGZ	417	417	113	37	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KGZ	FSU	Central Asia	REF												1992	1992		RoW							Kyrgyzstan	614
-Laos	Lao People's Democratic Republic	\blaos?\b	LA	LAO	418	418	120	12	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LAO	CPA	Southeastern Asia	OAS												1955	1955		RoW							Lao People's Democratic Republic	745
-Latvia	Republic of Latvia	latvia	LV	LVA	428	428	119	59	Europe	Northern Europe	LV	LV	LV	LVA	LVA	LVA	LVA	LVA	EEU	Central Europe	EUR	2016	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2014	1991	1991		EU						G20	Latvia	83
-Lebanon	Lebanese Republic	lebanon|lebanese	LB	LBN	422	422	121	146	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	LBN	MEA	Middle East	MEA												1945	1945		RoW							Lebanon	555
-Lesotho	Kingdom of Lesotho	lesotho|basuto	LS	LSO	426	426	122	194	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LSO	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Other Africa	249
-Liberia	Republic of Liberia	liberia	LR	LBR	430	430	123	210	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LBR	AFR	Western Africa	SSA												1945	1945		RoW							Other Africa	251
-Libya	State of Libya	libya	LY	LBY	434	434	124	147	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LBY	MEA	Northern Africa	MEA												1955	1955		RoW							Libya	133
-Liechtenstein	Principality of Liechtenstein	liechtenstein	LI	LIE	438	438	125		Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	LIE	WEU	Western Europe	NEU									EEA	Schengen		1990	1990		RoW								70
-Lithuania	Republic of Lithuania	lithuania	LT	LTU	440	440	126	60	Europe	Northern Europe	LT	LT	LT	LTU	LTU	LTU	LTU	LTU	EEU	Central Europe	EUR	2018	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2015	1991	1991		EU						G20	Lithuania	84
-Luxembourg	Grand Duchy of Luxembourg	^(?!.*belg).*luxem	LU	LUX	442	442	256	87	Europe	Western Europe	LU	LU	LU	LUX	LUX	LUX	LUX	LUX	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Luxembourg	22
-Macau	Macau SAR	.*maca(o|u)	MO	MAC	446	446	128		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MAC		China region	CHA															RoW							Other non-OECD Asia	
-North Macedonia	Republic of North Macedonia	macedonia|^f\.?y\.?r\.?o\.?m\.?$	MK	MKD	807	807	154	49	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MKD	EEU	Central Europe	NEU												1993	1993		RoW							Republic of North Macedonia	66
-Madagascar	Republic of Madagascar	madagascar|malagasy	MG	MDG	450	450	129	181	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MDG	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	252
-Malawi	Republic of Malawi	malawi|nyasa	MW	MWI	454	454	130	182	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MWI	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Other Africa	253
-Malaysia	Malaysia	malaysia	MY	MYS	458	458	131	13	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MYS	PAS	Southeastern Asia	OAS												1957	1957		RoW		APEC					Malaysia	751
-Maldives	Republic of Maldives	maldive	MV	MDV	462	462	132	14	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MDV	SAS	Rest of South Asia	OAS												1965	1965		RoW							Other non-OECD Asia	655
-Mali	Republic of Mali	\bmali\b	ML	MLI	466	466	133	211	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MLI	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	255
-Malta	Republic of Malta	\bmalta	MT	MLT	470	470	134	88	Europe	Southern Europe	MT	MT	MT	MLT	MLT	MLT	MLT	MLT	WEU	Western Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2008	1964	1964		EU						G20	Malta	45
-Marshall Islands	Republic of the Marshall Islands	marshall	MH	MHL	584	584	127	24	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MHL		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	859
-Martinique	Martinique	martinique	MQ	MTQ	474	474	135		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MTQ	LAC	Central America	LAM															RoW							Other non-OECD Americas	
-Mauritania	Islamic Republic of Mauritania	mauritania	MR	MRT	478	478	136	212	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MRT	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	256
-Mauritius	Republic of Mauritius	mauritius	MU	MUS	480	480	137	183	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MUS	AFR	Eastern Africa	SSA												1968	1968		RoW							Mauritius	257
-Mayotte	Mayotte	mayotte	YT	MYT	175	175	270		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MYT			SSA															RoW							Other Africa	
-Mexico	United Mexican States	^(?!.*new).*mexi(?!.*city)	MX	MEX	484	484	138	130	America	Central America	MX	MX	MX	MEX	MEX	MEX	MEX	MEX	LAC	Mexico	LAM	1994											1945	1945		BX		APEC				G20	Mexico	358
-"Micronesia, Fed. Sts."	Federated States of Micronesia	micronesia	FM	FSM	583	583	145	25	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	FSM		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	860
-Moldova	Republic of Moldova	moldov|b(a|e)ssarabia	MD	MDA	498	498	146	61	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MDA	FSU	Ukraine region	REF												1992	1992		RoW				CIS			Republic of Moldova	93
-Monaco	Principality of Monaco	monaco	MC	MCO	492	492	140	367	Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MCO	WEU	Western Europe	NEU												1993	1993		RoW								
-Mongolia	Mongolia	mongolia	MN	MNG	496	496	141	38	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MNG	CPA	China region	OAS												1961	1961		RoW							Mongolia	753
-Montenegro	Montenegro	^(?!.*serbia).*montenegro	ME	MNE	499	499	273	50	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MNE		Central Europe	NEU												2006	2006		RoW							Montenegro	65
-Montserrat	Montserrat	montserrat	MS	MSR	500	500	142		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MSR		Central America	LAM															RoW							Other non-OECD Americas	385
-Morocco	Kingdom of Morocco	morocco|\bmaroc	MA	MAR	504	504	143	148	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MAR	MEA	Northern Africa	MEA												1956	1956		RoW							Morocco	136
-Mozambique	Republic of Mozambique	mozambique	MZ	MOZ	508	508	144	184	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MOZ	AFR	Rest of Southern Africa	SSA												1975	1975		RoW							Mozambique	259
-Myanmar	Republic of the Union of Myanmar	myanmar|burma	MM	MMR	104	104	28	15	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MMR	PAS	Southeastern Asia	OAS												1948	1948		RoW							Myanmar	635
-Namibia	Republic of Namibia	namibia	NA	NAM	516	516	147	195	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NAM	AFR	Rest of Southern Africa	SSA												1990	1990		RoW							Namibia	275
-Nauru	Republic of Nauru	nauru	NR	NRU	520	520	148	369	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NRU		Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	845
-Nepal	Federal Democratic Republic of Nepal	nepal	NP	NPL	524	524	149	164	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	NPL	SAS	Rest of South Asia	OAS												1955	1955		RoW							Nepal	660
-Netherlands	Kingdom of the Netherlands	^(?!.*\bant)(?!.*\bcarib).*netherlands	NL	NLD	528	528	150	89	Europe	Western Europe	NL	NL	NL	NLD	NLD	NLD	NLD	NLD	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Netherlands	7
-Netherlands Antilles	Netherlands Antilles	^(?=.*\bant).*(neth.*|dutch)	AN	ANT	530		151		America		WW	WL	WL	WWW	WWL	WWL	RoW	ANT	LAC	Central America															2010	RoW								
-New Caledonia	New Caledonia	new.?caledonia	NC	NCL	540	540	153		Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	NCL	PAS	Oceania	OAS															RoW							Other non-OECD Asia	
-New Zealand	New Zealand	(new|n).*zealand	NZ	NZL	554	554	156	72	Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NZL	PAO	Oceania	CAZ	1973											1945	1945		RoW		APEC					New Zealand	820
-Nicaragua	Republic of Nicaragua	nicaragua	NI	NIC	558	558	157	131	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	NIC	LAC	Central America	LAM												1945	1945		RoW							Nicaragua	364
-Niger	Republic of Niger	\bniger(?!ia)	NE	NER	562	562	158	213	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NER	AFR	Western Africa	SSA												1960	1960		RoW							Niger	260
-Nigeria	Federal Republic of Nigeria	nigeria	NG	NGA	566	566	159	214	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NGA	AFR	Western Africa	SSA												1960	1960		RoW							Nigeria	261
-Niue	Niue	niue	NU	NIU	570	570	160	374	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NIU		Oceania	OAS															RoW							Other non-OECD Asia	856
-Norfolk Island	Norfolk Island	norfolk.*is	NF	NFK	574	574	161		Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NFK			OAS															RoW							Other non-OECD Asia	
-North Korea	Democratic People's Republic of Korea	^(?=.*dem).*\bkorea|^(?=.*peo).*\bkorea|^(?=.*nor).*\bkorea|\bd\.?p\.?r\.|.*dpr.*|^n.*korea	KP	PRK	408	408	116	7	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PRK	CPA	Korea region	OAS												1991	1991		RoW							Democratic People's Republic of Korea	740
-Northern Mariana Islands	Northern Mariana Islands	mariana	MP	MNP	580	580	163	376	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MNP		Oceania	OAS															RoW							Other non-OECD Asia	
-Norway	Kingdom of Norway	norway	NO	NOR	578	578	162	90	Europe	Northern Europe	NO	NO	NO	NOR	NOR	NOR	RoW	NOR	WEU	Western Europe	NEU	1961								EEA	Schengen		1945	1945		HI							Norway	8
-Oman	Sultanate of Oman	\boman|trucial	OM	OMN	512	512	221	150	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	OMN	MEA	Middle East	MEA												1971	1971		RoW							Oman	
-Pakistan	Islamic Republic of Pakistan	^(?!.*east).*paki?stan	PK	PAK	586	586	165	165	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PAK	SAS	Rest of South Asia	OAS												1947	1947		RoW							Pakistan	665
-Palau	Republic of Palau	palau	PW	PLW	585	585	180	380	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	PLW		Oceania	OAS												1994	1994		RoW							Other non-OECD Asia	861
-Palestine	State of Palestine	palestin|\bgaza|west.?bank	PS	PSE	275	275	299	149	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	PSE			MEA															RoW							Other non-OECD Asia	550
-Panama	Republic of Panama	panama	PA	PAN	591	591	166	132	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	PAN	LAC	Central America	LAM												1945	1945		RoW							Panama	366
-Papua New Guinea	Independent State of Papua New Guinea	\bp.*\bn.*\bguin.*|^p\.?n\.?g\.?$|new.?guinea	PG	PNG	598	598	168	26	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	PNG	PAS	Indonesia region	OAS												1975	1975		RoW		APEC					Other non-OECD Asia	862
-Paraguay	Republic of Paraguay	paraguay	PY	PRY	600	600	169	136	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PRY	LAC	Rest of South America	LAM												1945	1945		RoW							Paraguay	451
-Peru	Republic of Peru	peru	PE	PER	604	604	170	123	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PER	LAC	Rest of South America	LAM												1945	1945		RoW		APEC					Peru	454
-Philippines	Republic of the Philippines	philippines	PH	PHL	608	608	171	16	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PHL	PAS	Southeastern Asia	OAS												1945	1945		RoW		APEC					Philippines	755
-Pitcairn	Pitcairn	pitcairn	PN	PCN	612	612	172		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PCN		Oceania	OAS															RoW							Other non-OECD Asia	
-Poland	Republic of Poland	poland	PL	POL	616	616	173	51	Europe	Eastern Europe	PL	PL	PL	POL	POL	POL	POL	POL	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1945	1945		EU						G20	Poland	76
-Portugal	Portuguese Republic	portugal|portuguese	PT	PRT	620	620	174	91	Europe	Southern Europe	PT	PT	PT	PRT	PRT	PRT	PRT	PRT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Portugal	9
-Puerto Rico	Puerto Rico	puerto.?rico	PR	PRI	630	630	177	385	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		NAM	Central America	LAM															RoW							Other non-OECD Americas	
-Qatar	State of Qatar	qatar	QA	QAT	634	634	179	151	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	QAT	MEA	Middle East	MEA												1971	1971		RoW							Qatar	561
-Reunion	Reunion	reunion|réunion	RE	REU	638	638	182		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	REU	AFR	Eastern Africa	SSA															RoW							Other Africa	
-Romania	Romania	r(o|u|ou)mania	RO	ROU	642	642	183	52	Europe	Eastern Europe	RO	RO	RO	ROM	ROM	ROM	ROU	ROU	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Romania	77
-Russia	Russian Federation	\brussia	RU	RUS	643	643	185	62	Europe	Eastern Europe	RU	RU	RU	RUS	RUS	RUS	RUS	RUS	FSU	Russia region	REF												1945	1945		BX	BRIC	APEC		CIS		G20	Russian Federation	87
-Rwanda	Republic of Rwanda	rwanda	RW	RWA	646	646	184	185	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	RWA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	266
+name_short	name_official	regex	ISO2	ISO3	ISOnumeric	UNcode	FAOcode	GBDcode	continent	UNregion	EXIO1	EXIO2	EXIO3	EXIO1_3L	EXIO2_3L	EXIO3_3L	WIOD	Eora	MESSAGE	IMAGE	REMIND	OECD	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	EURO	UN	UNmember	obsolete	Cecilia2050	BRIC	APEC	BASIC	CIS	G7	G20	IEA	DACcode	ccTLD
+Afghanistan	Islamic Republic of Afghanistan	afghan	AF	AFG	4	4	2	160	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	AFG	SAS	Rest of South Asia	OAS												1946	1946		RoW							Other non-OECD Asia	625	af
+Aland Islands	Åland Islands	\b(a|å)land	AX	ALA	248	248	284		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ALA			EUR															RoW	ax
+Albania	Republic of Albania	albania	AL	ALB	8	8	3	43	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ALB	EEU	Central Europe	NEU												1955	1955		RoW							Albania	71	al
+Algeria	People's Democratic Republic of Algeria	algeria	DZ	DZA	12	12	4	139	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	DZA	MEA	Northern Africa	MEA												1962	1962		RoW							Algeria	130	dz
+American Samoa	American Samoa	^(?=.*americ).*samoa	AS	ASM	16	16	5	298	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	ASM	PAS	Oceania	OAS															RoW							Other non-OECD Asia	880	as
+Andorra	Principality of Andorra	andorra	AD	AND	20	20	6	74	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	AND	WEU	Western Europe	NEU												1993	1993		RoW	ad
+Angola	Republic of Angola	angola	AO	AGO	24	24	7	168	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	AGO	AFR	Rest of Southern Africa	SSA												1976	1976		RoW							Angola	225	ao
+Anguilla	Anguilla	anguill?a	AI	AIA	660	660	258		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	AIA		Central America	LAM															RoW							Other non-OECD Americas	ai
+Antarctica	Antarctica	antarctica	AQ	ATA	10	10	30		Antarctica	Antarctica	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	aq
+Antigua and Barbuda	Antigua and Barbuda	antigua	AG	ATG	28	28	8	105	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ATG	LAC		LAM												1981	1981		RoW							Other non-OECD Americas	377	ag
+Argentina	Argentine Republic	argentin	AR	ARG	32	32	9	97	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	ARG	LAC	Rest of South America	LAM												1945	1945		RoW						G20	Argentina	425	ar
+Armenia	Republic of Armenia	armenia	AM	ARM	51	51	1	33	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	ARM	FSU	Russia region	REF												1992	1992		RoW				CIS			Armenia	610	am
+Aruba	Aruba	^(?!.*bonaire).*\baruba	AW	ABW	533	533	22		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ABW		Central America	LAM															RoW							Other non-OECD Americas	aw
+Australia	Commonwealth of Australia	australia	AU	AUS	36	36	10	71	Oceania	Australia and New Zealand	AU	AU	AU	AUS	AUS	AUS	AUS	AUS	PAO	Oceania	CAZ	1971											1945	1945		HI		APEC				G20	Australia	801	au
+Austria	Republic of Austria	austria	AT	AUT	40	40	11	75	Europe	Western Europe	AT	AT	AT	AUT	AUT	AUT	AUT	AUT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Austria	1	at
+Azerbaijan	Republic of Azerbaijan	azerbaijan	AZ	AZE	31	31	52	34	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	AZE	FSU	Russia region	REF												1992	1992		RoW				CIS			Azerbaijan	611	az
+Bahamas	Commonwealth of the Bahamas	bahamas	BS	BHS	44	44	12	106	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	BHS	LAC	Central America	LAM												1973	1973		RoW							Other non-OECD Americas	bs
+Bahrain	Kingdom of Bahrain	bahrain	BH	BHR	48	48	13	140	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	BHR	MEA	Middle East	MEA												1971	1971		RoW							Bahrain	bh
+Bangladesh	People's Republic of Bangladesh	bangladesh|^(?=.*east).*paki?stan	BD	BGD	50	50	16	161	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BGD	SAS	Rest of South Asia	OAS												1974	1974		RoW							Bangladesh	666	bd
+Barbados	Barbados	barbados	BB	BRB	52	52	14	107	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	BRB	LAC	Central America	LAM												1966	1966		RoW							Other non-OECD Americas	bb
+Belarus	Republic of Belarus	belarus|byelo	BY	BLR	112	112	57	57	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	BLR	FSU	Ukraine region	REF												1945	1945		RoW				CIS			Belarus	86	by
+Belgium	Kingdom of Belgium	^(?!.*luxem).*belgium	BE	BEL	56	56	255	76	Europe	Western Europe	BE	BE	BE	BEL	BEL	BEL	BEL	BEL	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Belgium	2	be
+Belize	Belize	belize|^(?=.*british).*honduras	BZ	BLZ	84	84	23	108	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	BLZ	LAC	Central America	LAM												1981	1981		RoW							Other non-OECD Americas	352	bz
+Benin	Republic of Benin	benin|dahome	BJ	BEN	204	204	53	200	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BEN	AFR	Western Africa	SSA												1960	1960		RoW							Benin	236	bj
+Bermuda	Bermuda	bermuda	BM	BMU	60	60	17	305	America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	BMU	LAC	Central America	LAM															RoW							Other non-OECD Americas	bm
+Bhutan	Kingdom of Bhutan	bhutan	BT	BTN	64	64	18	162	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BTN	SAS	Rest of South Asia	OAS												1971	1971		RoW							Other non-OECD Asia	630	bt
+Bolivia	Plurinational State of Bolivia	bolivia	BO	BOL	68	68	19	121	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	BOL	LAC	Rest of South America	LAM												1945	1945		RoW							Plurinational State of Bolivia	428	bo
+"Bonaire, Saint Eustatius and Saba"	"Bonaire, Saint Eustatius and Saba"	^(?=.*bonaire).*eustatius|^(?=.*carib).*netherlands|\bbes.?islands	BQ	BES	535	535	278		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas	bq
+Bosnia and Herzegovina	Bosnia and Herzegovina	herzegovina|bosnia	BA	BIH	70	70	80	44	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	BIH	EEU	Central Europe	NEU												1992	1992		RoW							Bosnia and Herzegovina	64	ba
+Botswana	Republic of Botswana	botswana|bechuana	BW	BWA	72	72	20	193	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BWA	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Botswana	227	bw
+Bouvet Island	Bouvet Island	bouvet	BV	BVT	74	74	31		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	bv
+Brazil	Federative Republic of Brazil	brazil	BR	BRA	76	76	21	135	America	South America	BR	BR	BR	BRA	BRA	BRA	BRA	BRA	LAC	Brazil	LAM												1945	1945		BX	BRIC		BASIC			G20	Brazil	431	br
+British Antarctic Territories	British Antarctic Territories	br.*antarctic.?territ.*	B1	BA1					Antarctica		WW	WA	WA	WWW	WWA	WWA	RoW																		1979	RoW	
+British Indian Ocean Territory	British Indian Ocean Territory	br.*indian.?ocean	IO	IOT	86	86	24		Africa	Eastern Africa	WW	WA	WA	WWW	WWA	WWA	RoW		AFR		OAS															RoW							Other non-OECD Asia	io
+British Virgin Islands	British Virgin Islands	^(?=.*\bu\.?\s?k).*virgin|^(?=.*br.*).*virgin|^(?=.*kingdom).*virgin|BVI	VG	VGB	92	92	239		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VGB		Central America	LAM															RoW							Other non-OECD Americas	vg
+Brunei Darussalam	"Nation of Brunei, Abode of Peace"	brunei	BN	BRN	96	96	26	66	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BRN	PAS	Southeastern Asia	OAS												1984	1984		RoW		APEC					Brunei Darussalam	bn
+Bulgaria	Republic of Bulgaria	bulgaria	BG	BGR	100	100	27	45	Europe	Eastern Europe	BG	BG	BG	BGR	BGR	BGR	BGR	BGR	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Bulgaria	72	bg
+Burkina Faso	Burkina Faso	burkina|\bfaso|upper.?volta	BF	BFA	854	854	233	201	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BFA	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	287	bf
+Burundi	Republic of Burundi	burundi	BI	BDI	108	108	29	175	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BDI	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	228	bi
+Cabo Verde	Republic of Cabo Verde	(cabo|cape) *verde	CV	CPV	132	132	35	203	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CPV	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	230	cv
+Cambodia	Kingdom of Cambodia	cambodia|kampuchea|khmer|^p\.?r\.?k\.?$	KH	KHM	116	116	115	10	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KHM	CPA	Southeastern Asia	OAS												1955	1955		RoW							Cambodia	728	kh
+Cameroon	Republic of Cameroon	cameroon	CM	CMR	120	120	32	202	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CMR	AFR	Western Africa	SSA												1960	1960		RoW							Cameroon	229	cm
+Canada	Canada	canada	CA	CAN	124	124	33	101	America	Northern America	CA	CA	CA	CAN	CAN	CAN	CAN	CAN	NAM	Canada	CAZ	1961											1945	1945		HI		APEC			G7	G20	Canada	301	ca
+Cayman Islands	Cayman Islands	cayman	KY	CYM	136	136	36		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CYM		Central America	LAM															RoW							Other non-OECD Americas	ky
+Central African Republic	Central African Republic	central.?african.?rep.*	CF	CAF	140	140	37	169	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CAF	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	231	cf
+Chad	Republic of Chad	\bchad	TD	TCD	148	148	39	204	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TCD	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	232	td
+Channel Islands	Channel Islands	channel.?island.*		CHI	830	830	259		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW		WEU											EEA					2006	RoW	
+Chile	Republic of Chile	\bchile	CL	CHL	152	152	40	98	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	CHL	LAC	Rest of South America	LAM	2010											1945	1945		RoW		APEC					Chile	cl
+China	People's Republic of China	^(?!repub)(?!taiwan)(?!hong.*kong)(?!macao).*china(?!.*hong.*kong)(?!.*macao)|^PRC$	CN	CHN	156	156	351	6	Asia	Eastern Asia	CN	CN	CN	CHN	CHN	CHN	CHN	CHN	CPA	China region	CHA												1945	1945		BX	BRIC	APEC	BASIC			G20	People's Republic of China	730	cn
+Christmas Island	Christmas Island	christmas	CX	CXR	162	162	42		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia	cx
+Cocos (Keeling) Islands	Territory of the Cocos (Keeling) Islands	\bcocos|keeling	CC	CCK	166	166	43		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia	cc
+Colombia	Republic of Colombia	colombia	CO	COL	170	170	44	125	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	COL	LAC	Rest of South America	LAM	2020											1945	1945		RoW							Colombia	437	co
+Comoros	Union of the Comoros	comoro	KM	COM	174	174	45	176	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COM	AFR	Eastern Africa	SSA												1975	1975		RoW							Other Africa	233	km
+Congo Republic	Republic of the Congo	"^(?!.*\bdem)(?!.*\bdr)(?!.*kinshasa)(?!.*zaire)(?!.*belg)(?!.*l\w{1,2}opoldville)(?!.*free)(^rep.*).*\bcongo.*(?!.*\bdem)(?!.*\bdr).*|\bwest.*congo|^congo[,;\s]*(?!.*dem)rep.*?$|^congo$|\bcongo.*brazza.*"	CG	COG	178	178	46	170	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COG	AFR	Western Africa	SSA												1960	1960		RoW							Republic of the Congo	234	cg
+Cook Islands	Cook Islands	\bcook	CK	COK	184	184	47	320	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	COK		Oceania	OAS															RoW							Other non-OECD Asia	ck
+Costa Rica	Republic of Costa Rica	costa.?rica	CR	CRI	188	188	48	126	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	CRI	LAC	Central America	LAM												1945	1945		RoW							Costa Rica	336	cr
+Cote d'Ivoire	Republic of Côte d'Ivoire	.*(ivoire|ivory)	CI	CIV	384	384	107	205	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CIV	AFR	Western Africa	SSA												1960	1960		RoW							Côte d'Ivoire	247	ci
+Croatia	Republic of Croatia	croatia|hrvatska	HR	HRV	191	191	98	46	Europe	Southern Europe	WW	WE	HR	WWW	WWE	HRV	RoW	HRV	EEU	Central Europe	EUR		EU	EU28	EU27					EEA			1992	1992		RoW						G20	Croatia	62	hr
+Cuba	Republic of Cuba	\bcuba	CU	CUB	192	192	49	109	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CUB	LAC		LAM												1945	1945		RoW							Cuba	338	cu
+Curacao	Country of Curaçao	\bcura(c|ç)ao	CW	CUW	531	531	279		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Curaçao/Netherlands Antilles	cw
+Cyprus	Republic of Cyprus	cyprus	CY	CYP	196	196	50	77	Asia	Western Asia	CY	CY	CY	CYP	CYP	CYP	CYP	CYP	WEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA		2008	1960	1960		EU						G20	Cyprus	30	cy
+Czech Republic	Czech Republic	^(?=.*rep).*czech.*|czechia|bohemia|.*czech.*	CZ	CZE	203	203	167	47	Europe	Eastern Europe	CZ	CZ	CZ	CZE	CZE	CZE	CZE	CZE	EEU	Central Europe	EUR	1995	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1993	1993		EU						G20	Czech Republic	68	cz
+Denmark	Kingdom of Denmark	denmark	DK	DNK	208	208	54	78	Europe	Northern Europe	DK	DK	DK	DNK	DNK	DNK	DNK	DNK	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen		1945	1945		EU						G20	Denmark	3	dk
+Djibouti	Republic of Djibouti	djibouti	DJ	DJI	262	262	72	177	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	DJI	AFR	Eastern Africa	SSA												1977	1977		RoW							Other Africa	274	dj
+Dominica	Commonwealth of Dominica	dominica(?!n)	DM	DMA	212	212	55	110	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	DMA	LAC	Central America	LAM												1978	1978		RoW							Other non-OECD Americas	378	dm
+Dominican Republic	Dominican Republic	dominican	DO	DOM	214	214	56	111	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	DOM	LAC	Central America	LAM												1945	1945		RoW							Dominican Republic	340	do
+DR Congo	Democratic Republic of the Congo	"\bdem.*congo|congo.*\bdem|congo.*\bdr|\bdr.*congo|\bd\.?r\.?c|\bd\.?r\.?o\.?c|\br\.?d\.?c|belgian.?congo|congo.?free.?state|kinshasa|zaire|l\w{1,2}opoldville|^the\ congo$|^RDC$|^DROC$|\bcongo.*dem.*"	CD	COD	180	180	250	171	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COD	AFR	Western Africa	SSA												1960	1960		RoW							Democratic Republic of the Congo	235	cd
+Ecuador	Republic of Ecuador	ecuador	EC	ECU	218	218	58	122	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	ECU	LAC	Rest of South America	LAM												1945	1945		RoW							Ecuador	440	ec
+Egypt	Arab Republic of Egypt	egypt	EG	EGY	818	818	59	141	Africa	Northern Africa	WW	WM	WM	WWW	WWM	WWM	RoW	EGY	MEA	Northern Africa	MEA												1945	1945		RoW							Egypt	142	eg
+El Salvador	Republic of El Salvador	el.?salvador	SV	SLV	222	222	60	127	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	SLV	LAC	Central America	LAM												1945	1945		RoW							El Salvador	342	sv
+Equatorial Guinea	Republic of Equatorial Guinea	guine.*eq|eq.*guine|^(?=.*span).*guinea	GQ	GNQ	226	226	61	172	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GNQ	AFR	Western Africa	SSA												1968	1968		RoW							Equatorial Guinea	245	gq
+Eritrea	State of Eritrea	eritrea	ER	ERI	232	232	178	178	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ERI	AFR	Eastern Africa	SSA												1993	1993		RoW							Eritrea	271	er
+Estonia	Republic of Estonia	estonia	EE	EST	233	233	63	58	Europe	Northern Europe	EE	EE	EE	EST	EST	EST	EST	EST	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2011	1991	1991		EU						G20	Estonia	82	ee
+Eswatini	Kingdom of Eswatini	swaziland|eswatini	SZ	SWZ	748	748	209	197	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SWZ	AFR	Rest of Southern Africa	SSA												1968	1968		RoW							Other Africa	280	sz
+Ethiopia	Federal Democratic Republic of Ethiopia	ethiopia|abyssinia	ET	ETH	231	231	238	179	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ETH	AFR	Eastern Africa	SSA												1945	1945		RoW							Ethiopia	238	et
+Faeroe Islands	Faeroe Islands	faroe|faeroe	FO	FRO	234	234	64		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	FRO	WEU	Western Europe	EUR										Schengen					RoW	fo
+Falkland Islands	Falkland Islands (Malvinas)	falkland|malvinas	FK	FLK	238	238	65		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	FLK		Rest of South America	LAM															RoW							Other non-OECD Americas	fk
+Fiji	Republic of Fiji	fiji	FJ	FJI	242	242	66	22	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	FJI	PAS	Oceania	OAS												1970	1970		RoW							Other non-OECD Asia	832	fj
+Finland	Republic of Finland	finland	FI	FIN	246	246	67	79	Europe	Northern Europe	FI	FI	FI	FIN	FIN	FIN	FIN	FIN	WEU	Western Europe	EUR	1969	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Finland	18	fi
+France	French Republic	^(?!.*\bdep).*france|french.?republic|\bgaul	FR	FRA	250	250	68	80	Europe	Western Europe	FR	FR	FR	FRA	FRA	FRA	FRA	FRA	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU					G7	G20	France	4	fr
+French Guiana	Guiana	^(?=.*french).*guiana|guiana	GF	GUF	254	254	69		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	GUF	LAC	Rest of South America	LAM															RoW							Other non-OECD Americas	gf
+French Polynesia	French Polynesia	french.?polynesia	PF	PYF	258	258	70		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PYF	PAS	Oceania	OAS															RoW							Other non-OECD Asia	pf
+French Southern Territories	Territory of the French Southern and Antarctic Lands	french.?southern|\bfr.*\bso.*\ban.*\b\bt	TF	ATF	260	260	71		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW				OAS															RoW							Other Africa	tf
+Gabon	Gabonese Republic	gabon	GA	GAB	266	266	74	173	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GAB	AFR	Western Africa	SSA												1960	1960		RoW							Gabon	239	ga
+Gambia	Republic of the Gambia	gambia	GM	GMB	270	270	75	206	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GMB	AFR	Western Africa	SSA												1965	1965		RoW							Other Africa	240	gm
+Georgia	Georgia	^(?!.*south).*georgia(?!.*US.*)	GE	GEO	268	268	73	35	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	GEO	FSU	Russia region	REF												1992	1992		RoW							Georgia	612	ge
+Germany	Federal Republic of Germany	"^(?!e|w)(fed)?.*germany(?!,? *e|,? *w)(,? *)(\bfed)?"	DE	DEU	276	276	79	81	Europe	Western Europe	DE	DE	DE	DEU	DEU	DEU	DEU	DEU	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1973	1973		EU					G7	G20	Germany	5	de
+Ghana	Republic of Ghana	ghana|gold.?coast	GH	GHA	288	288	81	207	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GHA	AFR	Western Africa	SSA												1957	1957		RoW							Ghana	241	gh
+Gibraltar	Gibraltar	gibraltar	GI	GIB	292	292	82		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	GIB	WEU	Western Europe	EUR									EEA						RoW							Gibraltar	gi
+Greece	Hellenic Republic	greece|hellenic|hellas	GR	GRC	300	300	84	82	Europe	Southern Europe	GR	GR	GR	GRC	GRC	GRC	GRC	GRC	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	2001	1945	1945		EU						G20	Greece	40	gr
+Greenland	Greenland	greenland	GL	GRL	304	304	85	349	America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	GRL	WEU		NEU										Schengen					RoW							Other non-OECD Americas	gl
+Grenada	Grenada	grenada	GD	GRD	308	308	86	112	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	GRD	LAC	Central America	LAM												1974	1974		RoW							Other non-OECD Americas	381	gd
+Guadeloupe	Guadeloupe	guadeloupe	GP	GLP	312	312	87		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	GLP	LAC	Central America	LAM															RoW							Other non-OECD Americas	gp
+Guam	Guam	\bguam	GU	GUM	316	316	88	351	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	GUM	NAM		OAS															RoW							Other non-OECD Asia	gu
+Guatemala	Republic of Guatemala	guatemala	GT	GTM	320	320	89	128	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	GTM	LAC	Central America	LAM												1945	1945		RoW							Guatemala	347	gt
+Guernsey	Guernsey	guernsey	GG	GGY	831	831			Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	GGY			EUR									EEA						RoW	gg
+Guinea	Republic of Guinea	^(?!.*eq)(?!.*span)(?!.*bissau)(?!.*pap)(?!.*new)(?!p.*n.*).*guinea	GN	GIN	324	324	90	208	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GIN	AFR	Western Africa	SSA												1958	1958		RoW							Other Africa	243	gn
+Guinea-Bissau	Republic of Guinea-Bissau	^(.*portu).*guinea|guinea.*bissau	GW	GNB	624	624	175	209	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	GNB	AFR	Western Africa	SSA												1974	1974		RoW							Other Africa	244	gw
+Guyana	Co-operative Republic of Guyana	guyana|british.?guiana	GY	GUY	328	328	91	113	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	GUY	LAC	Rest of South America	LAM												1966	1966		RoW							Guyana	446	gy
+Haiti	Republic of Haiti	(ha(i|\xef|\xc3\xaf)ti)	HT	HTI	332	332	93	114	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	HTI	LAC	Central America	LAM												1945	1945		RoW							Haiti	349	ht
+Heard and McDonald Islands	Territory of Heard Island and McDonald Islands	heard.*mc.*donald	HM	HMD	334	334	92		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				CAZ															RoW							Other non-OECD Asia	hm
+Honduras	Republic of Honduras	^(?!.*brit).*honduras	HN	HND	340	340	95	129	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	HND	LAC	Central America	LAM												1945	1945		RoW							Honduras	351	hn
+Hong Kong	Hong Kong SAR	.*hong.*kong|hksar	HK	HKG	344	344	96		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	HKG	CPA	China region	CHA															RoW		APEC					Hong Kong (China)	hk
+Hungary	Republic of Hungary	hungary	HU	HUN	348	348	97	48	Europe	Eastern Europe	HU	HU	HU	HUN	HUN	HUN	HUN	HUN	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1955	1955		EU						G20	Hungary	75	hu
+Iceland	Republic of Iceland	iceland	IS	ISL	352	352	99	83	Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ISL	WEU	Western Europe	NEU	1961								EEA	Schengen		1946	1946		RoW							Iceland	20	is
+India	Republic of India	^(?!\D*(?:bassas))\D*india(?!.*ocea)(?!na)	IN	IND	356	356	100	163	Asia	Southern Asia	IN	IN	IN	IND	IND	IND	IND	IND	SAS	India	IND												1945	1945		BX	BRIC		BASIC			G20	India	645	in
+Indonesia	Republic of Indonesia	indonesia	ID	IDN	360	360	101	11	Asia	South-Eastern Asia	ID	ID	ID	IDN	IDN	IDN	IDN	IDN	PAS	Indonesia region	OAS												1950	1950		BX		APEC				G20	Indonesia	738	id
+Iran	Islamic Republic of Iran	\biran|persia	IR	IRN	364	364	102	142	Asia	Southern Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRN	MEA	Middle East	MEA												1945	1945		RoW							Islamic Republic of Iran	540	ir
+Iraq	Republic of Iraq	\biraq|mesopotamia	IQ	IRQ	368	368	103	143	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRQ	MEA	Middle East	MEA												1945	1945		RoW							Iraq	543	iq
+Ireland	Ireland	^(?!.*north.*).*ireland	IE	IRL	372	372	104	84	Europe	Northern Europe	IE	IE	IE	IRL	IRL	IRL	IRL	IRL	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA		1999	1955	1955		EU						G20	Ireland	21	ie
+Isle of Man	Isle of Man	^(?=.*isle).*\bman	IM	IMN	833	833	264		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	IMN	WEU		EUR									EEA						RoW	im
+Israel	State of Israel	israel	IL	ISR	376	376	105	85	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	ISR	MEA	Middle East	MEA	2010											1949	1949		RoW							Israel	546	il
+Italy	Italian Republic	.*italy|.*italia.*	IT	ITA	380	380	106	86	Europe	Southern Europe	IT	IT	IT	ITA	ITA	ITA	ITA	ITA	WEU	Western Europe	EUR	1962	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU					G7	G20	Italy	6	it
+Jamaica	Jamaica	jamaica	JM	JAM	388	388	109	115	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	JAM	LAC	Central America	LAM												1962	1962		RoW							Jamaica	354	jm
+Japan	Japan	japan	JP	JPN	392	392	110	67	Asia	Eastern Asia	JP	JP	JP	JPN	JPN	JPN	JPN	JPN	PAO	Japan	JPN	1964											1956	1956		HI		APEC			G7	G20	Japan	701	jp
+Jersey	Jersey	^(?!.*new).*jersey	JE	JEY	832	832	283		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	JEY			EUR									EEA						RoW	je
+Jordan	Hashemite Kingdom of Jordan	jordan	JO	JOR	400	400	112	144	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	JOR	MEA	Middle East	MEA												1955	1955		RoW							Jordan	549	jo
+Kazakhstan	Republic of Kazakhstan	kazak	KZ	KAZ	398	398	108	36	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KAZ	FSU	Central Asia	REF												1992	1992		RoW				CIS			Kazakhstan	613	kz
+Kenya	Republic of Kenya	kenya|british.?east.?africa|east.?africa.?prot	KE	KEN	404	404	114	180	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	KEN	AFR	Eastern Africa	SSA												1963	1963		RoW							Kenya	248	ke
+Kiribati	Republic of Kiribati	kiribati	KI	KIR	296	296	83	23	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	KIR	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	836	ki
+Kosovo	Republic of Kosovo	kosovo	XK	XKX					Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	KSV																		RoW							Kosovo	57	
+Kuwait	State of Kuwait	kuwait	KW	KWT	414	414	118	145	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	KWT	MEA	Middle East	MEA												1963	1963		RoW							Kuwait	552	kw
+Kyrgyz Republic	Kyrgyz Republic	kyrgyz|kirghiz	KG	KGZ	417	417	113	37	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KGZ	FSU	Central Asia	REF												1992	1992		RoW							Kyrgyzstan	614	kg
+Laos	Lao People's Democratic Republic	\blaos?\b	LA	LAO	418	418	120	12	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LAO	CPA	Southeastern Asia	OAS												1955	1955		RoW							Lao People's Democratic Republic	745	la
+Latvia	Republic of Latvia	latvia	LV	LVA	428	428	119	59	Europe	Northern Europe	LV	LV	LV	LVA	LVA	LVA	LVA	LVA	EEU	Central Europe	EUR	2016	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2014	1991	1991		EU						G20	Latvia	83	lv
+Lebanon	Lebanese Republic	lebanon|lebanese	LB	LBN	422	422	121	146	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	LBN	MEA	Middle East	MEA												1945	1945		RoW							Lebanon	555	lb
+Lesotho	Kingdom of Lesotho	lesotho|basuto	LS	LSO	426	426	122	194	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LSO	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Other Africa	249	ls
+Liberia	Republic of Liberia	liberia	LR	LBR	430	430	123	210	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LBR	AFR	Western Africa	SSA												1945	1945		RoW							Other Africa	251	lr
+Libya	State of Libya	libya	LY	LBY	434	434	124	147	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LBY	MEA	Northern Africa	MEA												1955	1955		RoW							Libya	133	ly
+Liechtenstein	Principality of Liechtenstein	liechtenstein	LI	LIE	438	438	125		Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	LIE	WEU	Western Europe	NEU									EEA	Schengen		1990	1990		RoW								70	li
+Lithuania	Republic of Lithuania	lithuania	LT	LTU	440	440	126	60	Europe	Northern Europe	LT	LT	LT	LTU	LTU	LTU	LTU	LTU	EEU	Central Europe	EUR	2018	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2015	1991	1991		EU						G20	Lithuania	84	lt
+Luxembourg	Grand Duchy of Luxembourg	^(?!.*belg).*luxem	LU	LUX	442	442	256	87	Europe	Western Europe	LU	LU	LU	LUX	LUX	LUX	LUX	LUX	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Luxembourg	22	lu
+Macau	Macau SAR	.*maca(o|u)	MO	MAC	446	446	128		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MAC		China region	CHA															RoW							Other non-OECD Asia	mo
+North Macedonia	Republic of North Macedonia	macedonia|^f\.?y\.?r\.?o\.?m\.?$	MK	MKD	807	807	154	49	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MKD	EEU	Central Europe	NEU												1993	1993		RoW							Republic of North Macedonia	66	mk
+Madagascar	Republic of Madagascar	madagascar|malagasy	MG	MDG	450	450	129	181	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MDG	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	252	mg
+Malawi	Republic of Malawi	malawi|nyasa	MW	MWI	454	454	130	182	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MWI	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Other Africa	253	mw
+Malaysia	Malaysia	malaysia	MY	MYS	458	458	131	13	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MYS	PAS	Southeastern Asia	OAS												1957	1957		RoW		APEC					Malaysia	751	my
+Maldives	Republic of Maldives	maldive	MV	MDV	462	462	132	14	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MDV	SAS	Rest of South Asia	OAS												1965	1965		RoW							Other non-OECD Asia	655	mv
+Mali	Republic of Mali	\bmali\b	ML	MLI	466	466	133	211	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MLI	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	255	ml
+Malta	Republic of Malta	\bmalta	MT	MLT	470	470	134	88	Europe	Southern Europe	MT	MT	MT	MLT	MLT	MLT	MLT	MLT	WEU	Western Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2008	1964	1964		EU						G20	Malta	45	mt
+Marshall Islands	Republic of the Marshall Islands	marshall	MH	MHL	584	584	127	24	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MHL		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	859	mh
+Martinique	Martinique	martinique	MQ	MTQ	474	474	135		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MTQ	LAC	Central America	LAM															RoW							Other non-OECD Americas	mq
+Mauritania	Islamic Republic of Mauritania	mauritania	MR	MRT	478	478	136	212	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MRT	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	256	mr
+Mauritius	Republic of Mauritius	mauritius	MU	MUS	480	480	137	183	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MUS	AFR	Eastern Africa	SSA												1968	1968		RoW							Mauritius	257	mu
+Mayotte	Mayotte	mayotte	YT	MYT	175	175	270		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MYT			SSA															RoW							Other Africa	yt
+Mexico	United Mexican States	^(?!.*new).*mexi(?!.*city)	MX	MEX	484	484	138	130	America	Central America	MX	MX	MX	MEX	MEX	MEX	MEX	MEX	LAC	Mexico	LAM	1994											1945	1945		BX		APEC				G20	Mexico	358	mx
+"Micronesia, Fed. Sts."	Federated States of Micronesia	micronesia	FM	FSM	583	583	145	25	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	FSM		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	860	fm
+Moldova	Republic of Moldova	moldov|b(a|e)ssarabia	MD	MDA	498	498	146	61	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MDA	FSU	Ukraine region	REF												1992	1992		RoW				CIS			Republic of Moldova	93	md
+Monaco	Principality of Monaco	monaco	MC	MCO	492	492	140	367	Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MCO	WEU	Western Europe	NEU												1993	1993		RoW	mc
+Mongolia	Mongolia	mongolia	MN	MNG	496	496	141	38	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MNG	CPA	China region	OAS												1961	1961		RoW							Mongolia	753	mn
+Montenegro	Montenegro	^(?!.*serbia).*montenegro	ME	MNE	499	499	273	50	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MNE		Central Europe	NEU												2006	2006		RoW							Montenegro	65	me
+Montserrat	Montserrat	montserrat	MS	MSR	500	500	142		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MSR		Central America	LAM															RoW							Other non-OECD Americas	385	ms
+Morocco	Kingdom of Morocco	morocco|\bmaroc	MA	MAR	504	504	143	148	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MAR	MEA	Northern Africa	MEA												1956	1956		RoW							Morocco	136	ma
+Mozambique	Republic of Mozambique	mozambique	MZ	MOZ	508	508	144	184	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MOZ	AFR	Rest of Southern Africa	SSA												1975	1975		RoW							Mozambique	259	mz
+Myanmar	Republic of the Union of Myanmar	myanmar|burma	MM	MMR	104	104	28	15	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MMR	PAS	Southeastern Asia	OAS												1948	1948		RoW							Myanmar	635	mm
+Namibia	Republic of Namibia	namibia	NA	NAM	516	516	147	195	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NAM	AFR	Rest of Southern Africa	SSA												1990	1990		RoW							Namibia	275	na
+Nauru	Republic of Nauru	nauru	NR	NRU	520	520	148	369	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NRU		Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	845	nr
+Nepal	Federal Democratic Republic of Nepal	nepal	NP	NPL	524	524	149	164	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	NPL	SAS	Rest of South Asia	OAS												1955	1955		RoW							Nepal	660	np
+Netherlands	Kingdom of the Netherlands	^(?!.*\bant)(?!.*\bcarib).*netherlands	NL	NLD	528	528	150	89	Europe	Western Europe	NL	NL	NL	NLD	NLD	NLD	NLD	NLD	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Netherlands	7	nl
+Netherlands Antilles	Netherlands Antilles	^(?=.*\bant).*(neth.*|dutch)	AN	ANT	530		151		America		WW	WL	WL	WWW	WWL	WWL	RoW	ANT	LAC	Central America															2010	RoW	
+New Caledonia	New Caledonia	new.?caledonia	NC	NCL	540	540	153		Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	NCL	PAS	Oceania	OAS															RoW							Other non-OECD Asia	nc
+New Zealand	New Zealand	(new|n).*zealand	NZ	NZL	554	554	156	72	Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NZL	PAO	Oceania	CAZ	1973											1945	1945		RoW		APEC					New Zealand	820	nz
+Nicaragua	Republic of Nicaragua	nicaragua	NI	NIC	558	558	157	131	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	NIC	LAC	Central America	LAM												1945	1945		RoW							Nicaragua	364	ni
+Niger	Republic of Niger	\bniger(?!ia)	NE	NER	562	562	158	213	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NER	AFR	Western Africa	SSA												1960	1960		RoW							Niger	260	ne
+Nigeria	Federal Republic of Nigeria	nigeria	NG	NGA	566	566	159	214	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NGA	AFR	Western Africa	SSA												1960	1960		RoW							Nigeria	261	ng
+Niue	Niue	niue	NU	NIU	570	570	160	374	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NIU		Oceania	OAS															RoW							Other non-OECD Asia	856	nu
+Norfolk Island	Norfolk Island	norfolk.*is	NF	NFK	574	574	161		Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NFK			OAS															RoW							Other non-OECD Asia	nf
+North Korea	Democratic People's Republic of Korea	^(?=.*dem).*\bkorea|^(?=.*peo).*\bkorea|^(?=.*nor).*\bkorea|\bd\.?p\.?r\.|.*dpr.*|^n.*korea	KP	PRK	408	408	116	7	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PRK	CPA	Korea region	OAS												1991	1991		RoW							Democratic People's Republic of Korea	740	kp
+Northern Mariana Islands	Northern Mariana Islands	mariana	MP	MNP	580	580	163	376	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MNP		Oceania	OAS															RoW							Other non-OECD Asia	mp
+Norway	Kingdom of Norway	norway	NO	NOR	578	578	162	90	Europe	Northern Europe	NO	NO	NO	NOR	NOR	NOR	RoW	NOR	WEU	Western Europe	NEU	1961								EEA	Schengen		1945	1945		HI							Norway	8	no
+Oman	Sultanate of Oman	\boman|trucial	OM	OMN	512	512	221	150	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	OMN	MEA	Middle East	MEA												1971	1971		RoW							Oman	om
+Pakistan	Islamic Republic of Pakistan	^(?!.*east).*paki?stan	PK	PAK	586	586	165	165	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PAK	SAS	Rest of South Asia	OAS												1947	1947		RoW							Pakistan	665	pk
+Palau	Republic of Palau	palau	PW	PLW	585	585	180	380	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	PLW		Oceania	OAS												1994	1994		RoW							Other non-OECD Asia	861	pw
+Palestine	State of Palestine	palestin|\bgaza|west.?bank	PS	PSE	275	275	299	149	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	PSE			MEA															RoW							Other non-OECD Asia	550	ps
+Panama	Republic of Panama	panama	PA	PAN	591	591	166	132	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	PAN	LAC	Central America	LAM												1945	1945		RoW							Panama	366	pa
+Papua New Guinea	Independent State of Papua New Guinea	\bp.*\bn.*\bguin.*|^p\.?n\.?g\.?$|new.?guinea	PG	PNG	598	598	168	26	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	PNG	PAS	Indonesia region	OAS												1975	1975		RoW		APEC					Other non-OECD Asia	862	pg
+Paraguay	Republic of Paraguay	paraguay	PY	PRY	600	600	169	136	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PRY	LAC	Rest of South America	LAM												1945	1945		RoW							Paraguay	451	py
+Peru	Republic of Peru	peru	PE	PER	604	604	170	123	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PER	LAC	Rest of South America	LAM												1945	1945		RoW		APEC					Peru	454	pe
+Philippines	Republic of the Philippines	philippines	PH	PHL	608	608	171	16	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PHL	PAS	Southeastern Asia	OAS												1945	1945		RoW		APEC					Philippines	755	ph
+Pitcairn	Pitcairn	pitcairn	PN	PCN	612	612	172		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PCN		Oceania	OAS															RoW							Other non-OECD Asia	pn
+Poland	Republic of Poland	poland	PL	POL	616	616	173	51	Europe	Eastern Europe	PL	PL	PL	POL	POL	POL	POL	POL	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1945	1945		EU						G20	Poland	76	pl
+Portugal	Portuguese Republic	portugal|portuguese	PT	PRT	620	620	174	91	Europe	Southern Europe	PT	PT	PT	PRT	PRT	PRT	PRT	PRT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Portugal	9	pt
+Puerto Rico	Puerto Rico	puerto.?rico	PR	PRI	630	630	177	385	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		NAM	Central America	LAM															RoW							Other non-OECD Americas	pr
+Qatar	State of Qatar	qatar	QA	QAT	634	634	179	151	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	QAT	MEA	Middle East	MEA												1971	1971		RoW							Qatar	561	qa
+Reunion	Reunion	reunion|réunion	RE	REU	638	638	182		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	REU	AFR	Eastern Africa	SSA															RoW							Other Africa	re
+Romania	Romania	r(o|u|ou)mania	RO	ROU	642	642	183	52	Europe	Eastern Europe	RO	RO	RO	ROM	ROM	ROM	ROU	ROU	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Romania	77	ro
+Russia	Russian Federation	\brussia	RU	RUS	643	643	185	62	Europe	Eastern Europe	RU	RU	RU	RUS	RUS	RUS	RUS	RUS	FSU	Russia region	REF												1945	1945		BX	BRIC	APEC		CIS		G20	Russian Federation	87	ru
+Rwanda	Republic of Rwanda	rwanda	RW	RWA	646	646	184	185	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	RWA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	266	rw
 Saint-Martin	Saint-Martin (French part)	^(?!.*maarten)(?!.*saba)(?!.*dutch).*martin\b	MF	MAF	663	663	281		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MAF			LAM															RoW							Other non-OECD Americas	
-Samoa	Independent State of Samoa	^(?!.*amer.*)samoa|(\bindep.*samoa)|^west.*samoa	WS	WSM	882	882	244	27	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WSM	PAS	Oceania	OAS												1976	1976		RoW							Other non-OECD Asia	
-San Marino	Republic of San Marino	san.?marino	SM	SMR	674	674	192	396	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SMR		Western Europe	NEU												1992	1992		RoW								
-Sao Tome and Principe	Democratic Republic of São Tomé and Príncipe	tome|tomé	ST	STP	678	678	193	215	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	STP	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	268
-Saudi Arabia	Kingdom of Saudi Arabia	\bsa\w*.?arabia	SA	SAU	682	682	194	152	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SAU	MEA	Middle East	MEA												1945	1945		RoW						G20	Saudi Arabia	566
-Senegal	Republic of Senegal	senegal	SN	SEN	686	686	195	216	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SEN	AFR	Western Africa	SSA												1960	1960		RoW							Senegal	269
-Serbia	Republic of Serbia	^(?!.*monte).*serbia.*	RS	SRB	688	688	272	53	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SRB		Central Europe	NEU												2000	2000		RoW							Serbia	63
-Seychelles	Republic of Seychelles	seychell	SC	SYC	690	690	196	186	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SYC	AFR	Eastern Africa	SSA												1976	1976		RoW							Other Africa	
-Sierra Leone	Republic of Sierra Leone	sierra	SL	SLE	694	694	197	217	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SLE	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	272
-Singapore	Republic of Singapore	singapore	SG	SGP	702	702	200	69	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	SGP	PAS	Southeastern Asia	OAS												1965	1965		RoW		APEC					Singapore	
-Sint Maarten	Sint Maarten (Dutch part)	^(?!.*martin)(?!.*saba).*maarten|dutch.*martin|martin.*dutch	SX	SXM	534	534	280		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas	
-Slovakia	Slovak Republic	^(?!.*cze).*slovak	SK	SVK	703	703	199	54	Europe	Eastern Europe	SK	SK	SK	SVK	SVK	SVK	SVK	SVK	EEU	Central Europe	EUR	2000	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2009	1993	1993		EU						G20	Slovak Republic	69
-Slovenia	Republic of Slovenia	slovenia	SI	SVN	705	705	198	55	Europe	Southern Europe	SI	SI	SI	SVN	SVN	SVN	SVN	SVN	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2007	1992	1992		EU						G20	Slovenia	61
-Solomon Islands	Solomon Islands	solomon	SB	SLB	90	90	25	28	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	SLB	PAS	Oceania	OAS												1978	1978		RoW							Other non-OECD Asia	866
-Somalia	Federal Republic of Somalia	somali	SO	SOM	706	706	201	187	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SOM	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	273
-South Africa	Republic of South Africa	\bs(\.|outh)(?!.*sahar).*africa|^r\.?s\.?a\.?$	ZA	ZAF	710	710	202	196	Africa	Southern Africa	ZA	ZA	ZA	ZAF	ZAF	ZAF	RoW	ZAF	AFR	South Africa	SSA												1945	1945		BX			BASIC			G20	South Africa	218
-South Georgia and South Sandwich Is.	South Georgia and The South Sandwich Islands	south.?georgia|sandwich	GS	SGS	239	239	271		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	
-South Korea	Republic of Korea	^(?!.*dem)(?!.*peo)(?!.*nor)(?!.*n)(?!.*dpr)(?!d\.p\.r).*\bkorea|\br\.?o\.?k\b	KR	KOR	410	410	117	68	Asia	Eastern Asia	KR	KR	KR	KOR	KOR	KOR	KOR	KOR	PAS	Korea region	OAS	1996											1991	1991		HI		APEC				G20	Korea	742
-South Sudan	Republic of South Sudan	\bs\w*.?sudan	SS	SSD	728	728	277	435	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SDS			SSA												2011	2011		RoW							South Sudan	279
-Soviet Union (former)	Union of Soviet Socialist Republics (former)	USSR|soviet	SU	SUN	810	810			Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	USR																	1992	RoW							Former Soviet Union (if no detail)	
-Spain	Kingdom of Spain	spain	ES	ESP	724	724	203	92	Europe	Southern Europe	ES	ES	ES	ESP	ESP	ESP	ESP	ESP	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Spain	50
-Sri Lanka	Democratic Socialist Republic of Sri Lanka	sri.?lanka|ceylon	LK	LKA	144	144	38	17	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LKA	SAS	Rest of South Asia	OAS												1955	1955		RoW							Sri Lanka	640
+Samoa	Independent State of Samoa	^(?!.*amer.*)samoa|(\bindep.*samoa)|^west.*samoa	WS	WSM	882	882	244	27	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WSM	PAS	Oceania	OAS												1976	1976		RoW							Other non-OECD Asia	ws
+San Marino	Republic of San Marino	san.?marino	SM	SMR	674	674	192	396	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SMR		Western Europe	NEU												1992	1992		RoW	sm
+Sao Tome and Principe	Democratic Republic of São Tomé and Príncipe	tome|tomé	ST	STP	678	678	193	215	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	STP	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	268	st
+Saudi Arabia	Kingdom of Saudi Arabia	\bsa\w*.?arabia	SA	SAU	682	682	194	152	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SAU	MEA	Middle East	MEA												1945	1945		RoW						G20	Saudi Arabia	566	sa
+Senegal	Republic of Senegal	senegal	SN	SEN	686	686	195	216	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SEN	AFR	Western Africa	SSA												1960	1960		RoW							Senegal	269	sn
+Serbia	Republic of Serbia	^(?!.*monte).*serbia.*	RS	SRB	688	688	272	53	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SRB		Central Europe	NEU												2000	2000		RoW							Serbia	63	rs
+Seychelles	Republic of Seychelles	seychell	SC	SYC	690	690	196	186	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SYC	AFR	Eastern Africa	SSA												1976	1976		RoW							Other Africa	sc
+Sierra Leone	Republic of Sierra Leone	sierra	SL	SLE	694	694	197	217	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SLE	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	272	sl
+Singapore	Republic of Singapore	singapore	SG	SGP	702	702	200	69	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	SGP	PAS	Southeastern Asia	OAS												1965	1965		RoW		APEC					Singapore	sg
+Sint Maarten	Sint Maarten (Dutch part)	^(?!.*martin)(?!.*saba).*maarten|dutch.*martin|martin.*dutch	SX	SXM	534	534	280		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas	sx
+Slovakia	Slovak Republic	^(?!.*cze).*slovak	SK	SVK	703	703	199	54	Europe	Eastern Europe	SK	SK	SK	SVK	SVK	SVK	SVK	SVK	EEU	Central Europe	EUR	2000	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2009	1993	1993		EU						G20	Slovak Republic	69	sk
+Slovenia	Republic of Slovenia	slovenia	SI	SVN	705	705	198	55	Europe	Southern Europe	SI	SI	SI	SVN	SVN	SVN	SVN	SVN	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2007	1992	1992		EU						G20	Slovenia	61	si
+Solomon Islands	Solomon Islands	solomon	SB	SLB	90	90	25	28	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	SLB	PAS	Oceania	OAS												1978	1978		RoW							Other non-OECD Asia	866	sb
+Somalia	Federal Republic of Somalia	somali	SO	SOM	706	706	201	187	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SOM	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	273	so
+South Africa	Republic of South Africa	\bs(\.|outh)(?!.*sahar).*africa|^r\.?s\.?a\.?$	ZA	ZAF	710	710	202	196	Africa	Southern Africa	ZA	ZA	ZA	ZAF	ZAF	ZAF	RoW	ZAF	AFR	South Africa	SSA												1945	1945		BX			BASIC			G20	South Africa	218	za
+South Georgia and South Sandwich Is.	South Georgia and The South Sandwich Islands	south.?georgia|sandwich	GS	SGS	239	239	271		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia	gs
+South Korea	Republic of Korea	^(?!.*dem)(?!.*peo)(?!.*nor)(?!.*n)(?!.*dpr)(?!d\.p\.r).*\bkorea|\br\.?o\.?k\b	KR	KOR	410	410	117	68	Asia	Eastern Asia	KR	KR	KR	KOR	KOR	KOR	KOR	KOR	PAS	Korea region	OAS	1996											1991	1991		HI		APEC				G20	Korea	742	kr
+South Sudan	Republic of South Sudan	\bs\w*.?sudan	SS	SSD	728	728	277	435	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SDS			SSA												2011	2011		RoW							South Sudan	279	ss
+Soviet Union (former)	Union of Soviet Socialist Republics (former)	USSR|soviet	SU	SUN	810	810			Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	USR																	1992	RoW							Former Soviet Union (if no detail)	su
+Spain	Kingdom of Spain	spain	ES	ESP	724	724	203	92	Europe	Southern Europe	ES	ES	ES	ESP	ESP	ESP	ESP	ESP	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Spain	50	es
+Sri Lanka	Democratic Socialist Republic of Sri Lanka	sri.?lanka|ceylon	LK	LKA	144	144	38	17	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LKA	SAS	Rest of South Asia	OAS												1955	1955		RoW							Sri Lanka	640	lk
 St. Barths	Territorial collectivity of Saint-Barthélemy	barth|barts	BL	BLM	652	652	282		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	BLM			LAM															RoW							Other non-OECD Americas	
-St. Helena	"Saint Helena, Ascension and Tristan da Cunha"	helena	SH	SHN	654	654	187		Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SHN	AFR	Western Africa	SSA															RoW							Other Africa	276
-St. Kitts and Nevis	Saint Kitts and Nevis	kitts|\bnevis	KN	KNA	659	659	188	393	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	KNA	LAC	Central America	LAM												1983	1983		RoW							Other non-OECD Americas	
-St. Lucia	Saint Lucia	\blucia	LC	LCA	662	662	189	116	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	LCA	LAC	Central America	LAM												1979	1979		RoW							Other non-OECD Americas	383
-St. Pierre and Miquelon	Saint Pierre and Miquelon	miquelon	PM	SPM	666	666	190		America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	SPM		USA	CAZ															RoW							Other non-OECD Americas	
-St. Vincent and the Grenadines	Saint Vincent and the Grenadines	vincent	VC	VCT	670	670	191	117	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VCT	LAC	Central America	LAM												1980	1980		RoW							Other non-OECD Americas	384
-Sudan	Republic of the Sudan	^(?!.*\bs(?!u)).*sudan	SD	SDN	729	729		522	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SUD	MEA	Eastern Africa	MEA												1956	1956		RoW							Sudan	278
-Suriname	Republic of Suriname	surinam|dutch.?guiana	SR	SUR	740	740	207	118	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	SUR	LAC	Rest of South America	LAM												1975	1975		RoW							Suriname	457
-Svalbard and Jan Mayen Islands	Svalbard and Jan Mayen Islands	^(?!norway).*svalbard	SJ	SJM	744	744	260		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SJM			NEU															RoW								
-Sweden	Kingdom of Sweden	swedish|sweden(?!.*except)	SE	SWE	752	752	210	93	Europe	Northern Europe	SE	SE	SE	SWE	SWE	SWE	SWE	SWE	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen		1946	1946		EU						G20	Sweden	10
-Switzerland	Swiss Confederation	switz|swiss	CH	CHE	756	756	211	94	Europe	Western Europe	CH	CH	CH	CHE	CHE	CHE	RoW	CHE	WEU	Western Europe	NEU	1961								EEA	Schengen		2002	2002		HI							Switzerland	11
-Syria	Syrian Arab Republic	syria	SY	SYR	760	760	212	153	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SYR	MEA	Middle East	MEA												1945	1945		RoW							Syrian Arab Republic	573
-Taiwan	Republic of China	.*taiwan|.*taipei|.*formosa|^(?!.*\bdem)(?!.*\bpe)(?!.*\bdr)(^rep.*).*\bchina.*(?!.*\bdem.*)(?!\bpe.*)(?!.*\bdr.*).*|^ROC$|^taiwan r\.?o\.?c\.?$	TW	TWN	158		214	8	Asia	Eastern Asia	TW	TW	TW	TWN	TWN	TWN	TWN	TWN	PAS	China region	CHA															HI		APEC					Chinese Taipei	732
-Tajikistan	Republic of Tajikistan	tajik	TJ	TJK	762	762	208	39	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TJK	FSU	Central Asia	REF												1992	1992		RoW				CIS			Tajikistan	615
+St. Helena	"Saint Helena, Ascension and Tristan da Cunha"	helena	SH	SHN	654	654	187		Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SHN	AFR	Western Africa	SSA															RoW							Other Africa	276 sh
+St. Kitts and Nevis	Saint Kitts and Nevis	kitts|\bnevis	KN	KNA	659	659	188	393	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	KNA	LAC	Central America	LAM												1983	1983		RoW							Other non-OECD Americas	kn
+St. Lucia	Saint Lucia	\blucia	LC	LCA	662	662	189	116	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	LCA	LAC	Central America	LAM												1979	1979		RoW							Other non-OECD Americas	383	lc
+St. Pierre and Miquelon	Saint Pierre and Miquelon	miquelon	PM	SPM	666	666	190		America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	SPM		USA	CAZ															RoW							Other non-OECD Americas	pm
+St. Vincent and the Grenadines	Saint Vincent and the Grenadines	vincent	VC	VCT	670	670	191	117	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VCT	LAC	Central America	LAM												1980	1980		RoW							Other non-OECD Americas	384	vc
+Sudan	Republic of the Sudan	^(?!.*\bs(?!u)).*sudan	SD	SDN	729	729		522	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SUD	MEA	Eastern Africa	MEA												1956	1956		RoW							Sudan	278	sd
+Suriname	Republic of Suriname	surinam|dutch.?guiana	SR	SUR	740	740	207	118	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	SUR	LAC	Rest of South America	LAM												1975	1975		RoW							Suriname	457	sr
+Svalbard and Jan Mayen Islands	Svalbard and Jan Mayen Islands	^(?!norway).*svalbard	SJ	SJM	744	744	260		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SJM			NEU															RoW	sj
+Sweden	Kingdom of Sweden	swedish|sweden(?!.*except)	SE	SWE	752	752	210	93	Europe	Northern Europe	SE	SE	SE	SWE	SWE	SWE	SWE	SWE	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen		1946	1946		EU						G20	Sweden	10	se
+Switzerland	Swiss Confederation	switz|swiss	CH	CHE	756	756	211	94	Europe	Western Europe	CH	CH	CH	CHE	CHE	CHE	RoW	CHE	WEU	Western Europe	NEU	1961								EEA	Schengen		2002	2002		HI							Switzerland	11	ch
+Syria	Syrian Arab Republic	syria	SY	SYR	760	760	212	153	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SYR	MEA	Middle East	MEA												1945	1945		RoW							Syrian Arab Republic	573	sy
+Taiwan	Republic of China	.*taiwan|.*taipei|.*formosa|^(?!.*\bdem)(?!.*\bpe)(?!.*\bdr)(^rep.*).*\bchina.*(?!.*\bdem.*)(?!\bpe.*)(?!.*\bdr.*).*|^ROC$|^taiwan r\.?o\.?c\.?$	TW	TWN	158		214	8	Asia	Eastern Asia	TW	TW	TW	TWN	TWN	TWN	TWN	TWN	PAS	China region	CHA															HI		APEC					Chinese Taipei	732	tw
+Tajikistan	Republic of Tajikistan	tajik	TJ	TJK	762	762	208	39	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TJK	FSU	Central Asia	REF												1992	1992		RoW				CIS			Tajikistan	615	tj
 Tanganjika	Republic of Tanganyika	tanganjika|tanganyika		EAT					Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW																		1964	RoW							Other Africa	
-Tanzania	United Republic of Tanzania	tanzania(?!: zan.*)	TZ	TZA	834	834	215	189	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TZA	AFR	Rest of Southern Africa	SSA												1961	1961		RoW							United Republic of Tanzania	282
-Thailand	Kingdom of Thailand	thailand|\bsiam	TH	THA	764	764	216	18	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	THA	PAS	Southeastern Asia	OAS												1946	1946		RoW		APEC					Thailand	764
-Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS		Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765
-Togo	Togolese Republic	togo	TG	TGO	768	768	217	218	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TGO	AFR	Western Africa	SSA												1960	1960		RoW							Togo	283
-Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TKL		Oceania	OAS															RoW							Other non-OECD Asia	868
-Tonga	Kingdom of Tonga	tonga	TO	TON	776	776	219	29	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TON	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	870
-Trinidad and Tobago	Republic of Trinidad and Tobago	trinidad|tobago	TT	TTO	780	780	220	119	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TTO	LAC	Central America	LAM												1962	1962		RoW							Trinidad and Tobago	
-Tunisia	Republic of Tunisia	tunisia	TN	TUN	788	788	222	154	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TUN	MEA	Northern Africa	MEA												1956	1956		RoW							Tunisia	139
-Turkey	Republic of Türkiye	t[ü|u]rk[i|e]y	TR	TUR	792	792	223	155	Asia	Western Asia	TR	TR	TR	TUR	TUR	TUR	TUR	TUR	WEU	Turkey	NEU	1961											1945	1945		BX						G20	Turkey	55
-Turkmenistan	Turkmenistan	turk-?men	TM	TKM	795	795	213	40	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TKM	FSU	Central Asia	REF												1992	1992		RoW							Turkmenistan	616
-Turks and Caicos Islands	Turks and Caicos Islands	turks	TC	TCA	796	796	224		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TCA		Central America	LAM															RoW							Other non-OECD Americas	
-Tuvalu	Tuvalu	tuvalu	TV	TUV	798	798	227	416	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TUV		Oceania	OAS												2000	2000		RoW							Other non-OECD Asia	872
-Uganda	Republic of Uganda	uganda	UG	UGA	800	800	226	190	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	UGA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	285
-Ukraine	Ukraine	ukrain	UA	UKR	804	804	230	63	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	UKR	FSU	Ukraine region	REF												1945	1945		RoW							Ukraine	85
-United Arab Emirates	United Arab Emirates	emirates|^u\.?a\.?e\.?$|united.?arab.?em	AE	ARE	784	784	225	156	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	ARE	MEA	Middle East	MEA												1971	1971		RoW							United Arab Emirates	576
-United Kingdom	United Kingdom of Great Britain and Northern Ireland	.*(united.?kingdom|britain|^u\.?k\.?$|gb)	^GB$|^UK$	GBR	826	826	229	95	Europe	Northern Europe	GB	GB	GB	GBR	GBR	GBR	GBR	GBR	WEU	Western Europe	EUR	1961		EU28		EU27_2007	EU25	EU15	EU12	EEA			1945	1945		EU					G7	G20	United Kingdom	12
-United States	United States of America	^(?!.*islands).*united.?states|^u\.?s\.?a\.?$|^u\.?s\.?$	US	USA	840	840	231	102	America	Northern America	US	US	US	USA	USA	USA	USA	USA	NAM	USA	USA	1961											1945	1945		HI		APEC			G7	G20	United States	302
+Tanzania	United Republic of Tanzania	tanzania(?!: zan.*)	TZ	TZA	834	834	215	189	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TZA	AFR	Rest of Southern Africa	SSA												1961	1961		RoW							United Republic of Tanzania	282	tz
+Thailand	Kingdom of Thailand	thailand|\bsiam	TH	THA	764	764	216	18	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	THA	PAS	Southeastern Asia	OAS												1946	1946		RoW		APEC					Thailand	764	th
+Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS		Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765	tl
+Togo	Togolese Republic	togo	TG	TGO	768	768	217	218	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TGO	AFR	Western Africa	SSA												1960	1960		RoW							Togo	283	tg
+Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TKL		Oceania	OAS															RoW							Other non-OECD Asia	868	tk
+Tonga	Kingdom of Tonga	tonga	TO	TON	776	776	219	29	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TON	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	870	to
+Trinidad and Tobago	Republic of Trinidad and Tobago	trinidad|tobago	TT	TTO	780	780	220	119	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TTO	LAC	Central America	LAM												1962	1962		RoW							Trinidad and Tobago	tt
+Tunisia	Republic of Tunisia	tunisia	TN	TUN	788	788	222	154	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TUN	MEA	Northern Africa	MEA												1956	1956		RoW							Tunisia	139	tn
+Turkey	Republic of Türkiye	t[ü|u]rk[i|e]y	TR	TUR	792	792	223	155	Asia	Western Asia	TR	TR	TR	TUR	TUR	TUR	TUR	TUR	WEU	Turkey	NEU	1961											1945	1945		BX						G20	Turkey	55	tr
+Turkmenistan	Turkmenistan	turk-?men	TM	TKM	795	795	213	40	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TKM	FSU	Central Asia	REF												1992	1992		RoW							Turkmenistan	616	tm
+Turks and Caicos Islands	Turks and Caicos Islands	turks	TC	TCA	796	796	224		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TCA		Central America	LAM															RoW							Other non-OECD Americas	tc
+Tuvalu	Tuvalu	tuvalu	TV	TUV	798	798	227	416	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TUV		Oceania	OAS												2000	2000		RoW							Other non-OECD Asia	872	tv
+Uganda	Republic of Uganda	uganda	UG	UGA	800	800	226	190	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	UGA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	285	ug
+Ukraine	Ukraine	ukrain	UA	UKR	804	804	230	63	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	UKR	FSU	Ukraine region	REF												1945	1945		RoW							Ukraine	85	ua
+United Arab Emirates	United Arab Emirates	emirates|^u\.?a\.?e\.?$|united.?arab.?em	AE	ARE	784	784	225	156	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	ARE	MEA	Middle East	MEA												1971	1971		RoW							United Arab Emirates	576	ae
+United Kingdom	United Kingdom of Great Britain and Northern Ireland	.*(united.?kingdom|britain|^u\.?k\.?$|gb)	^GB$|^UK$	GBR	826	826	229	95	Europe	Northern Europe	GB	GB	GB	GBR	GBR	GBR	GBR	GBR	WEU	Western Europe	EUR	1961		EU28		EU27_2007	EU25	EU15	EU12	EEA			1945	1945		EU					G7	G20	United Kingdom	12	uk
+United States	United States of America	^(?!.*islands).*united.?states|^u\.?s\.?a\.?$|^u\.?s\.?$	US	USA	840	840	231	102	America	Northern America	US	US	US	USA	USA	USA	USA	USA	NAM	USA	USA	1961											1945	1945		HI		APEC			G7	G20	United States	302	us
 United States Minor Outlying Islands	United States Minor Outlying Islands	minor.?outlying.?is	UM	UMI	581	581	232		Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia	
-United States Virgin Islands	Virgin Islands of the United States	^(?=.*\bu\.?\s?s).*virgin|^(?=.*states).*virgin	VI	VIR	850	850	240	422	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VIR	NAM	Central America	LAM															RoW							Other non-OECD Americas	
-Uruguay	Oriental Republic of Uruguay	uruguay	UY	URY	858	858	234	99	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	URY	LAC	Rest of South America	LAM												1945	1945		RoW							Uruguay	
-Uzbekistan	Republic of Uzbekistan	uzbek	UZ	UZB	860	860	235	41	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	UZB	FSU	Central Asia	REF												1992	1992		RoW				CIS			Uzbekistan	617
-Vanuatu	Republic of Vanuatu	vanuatu|new.?hebrides	VU	VUT	548	548	155	30	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	VUT	PAS	Oceania	OAS												1981	1981		RoW							Other non-OECD Asia	854
-Vatican	Vatican City State	holy.?see|vatican|papal.?st	VA	VAT	336	336	94		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	VAT		Western Europe	NEU															RoW								
-Venezuela	Bolivarian Republic of Venezuela	venezuela	VE	VEN	862	862	236	133	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	VEN	LAC	Rest of South America	LAM												1945	1945		RoW							Bolivarian Republic of Venezuela	463
-Vietnam	Socialist Republic of Vietnam	"^((?!n|s|.*republic)|(?=.*socialist)).*viet.?nam(?! *,? *n| *,? *s)"	VN	VNM	704	704	237	20	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	VNM	CPA	Southeastern Asia	OAS												1977	1977		RoW		APEC					Viet Nam	769
-Wallis and Futuna Islands	Wallis and Futuna Islands	futuna|wallis	WF	WLF	876	876	243		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WLF		Oceania	OAS															RoW							Other non-OECD Asia	876
-Western Sahara	Western Sahara	\bw.*sahara	EH	ESH	732	732	205	199	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ESH		Northern Africa	MEA															RoW							Other Africa	
-Yemen	Republic of Yemen	yemen	YE	YEM	887	887	249	157	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	YEM	MEA	Middle East	MEA												1947	1947		RoW							Yemen	580
-Zambia	Republic of Zambia	zambia|northern.?rhodesia	ZM	ZMB	894	894	251	191	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ZMB	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Zambia	288
+United States Virgin Islands	Virgin Islands of the United States	^(?=.*\bu\.?\s?s).*virgin|^(?=.*states).*virgin	VI	VIR	850	850	240	422	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VIR	NAM	Central America	LAM															RoW							Other non-OECD Americas	vi
+Uruguay	Oriental Republic of Uruguay	uruguay	UY	URY	858	858	234	99	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	URY	LAC	Rest of South America	LAM												1945	1945		RoW							Uruguay	uy
+Uzbekistan	Republic of Uzbekistan	uzbek	UZ	UZB	860	860	235	41	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	UZB	FSU	Central Asia	REF												1992	1992		RoW				CIS			Uzbekistan	617	uz
+Vanuatu	Republic of Vanuatu	vanuatu|new.?hebrides	VU	VUT	548	548	155	30	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	VUT	PAS	Oceania	OAS												1981	1981		RoW							Other non-OECD Asia	854	vu
+Vatican	Vatican City State	holy.?see|vatican|papal.?st	VA	VAT	336	336	94		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	VAT		Western Europe	NEU															RoW	va
+Venezuela	Bolivarian Republic of Venezuela	venezuela	VE	VEN	862	862	236	133	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	VEN	LAC	Rest of South America	LAM												1945	1945		RoW							Bolivarian Republic of Venezuela	463	ve
+Vietnam	Socialist Republic of Vietnam	"^((?!n|s|.*republic)|(?=.*socialist)).*viet.?nam(?! *,? *n| *,? *s)"	VN	VNM	704	704	237	20	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	VNM	CPA	Southeastern Asia	OAS												1977	1977		RoW		APEC					Viet Nam	769	vn
+Wallis and Futuna Islands	Wallis and Futuna Islands	futuna|wallis	WF	WLF	876	876	243		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WLF		Oceania	OAS															RoW							Other non-OECD Asia	876	wf
+Western Sahara	Western Sahara	\bw.*sahara	EH	ESH	732	732	205	199	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ESH		Northern Africa	MEA															RoW							Other Africa	eh
+Yemen	Republic of Yemen	yemen	YE	YEM	887	887	249	157	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	YEM	MEA	Middle East	MEA												1947	1947		RoW							Yemen	580	ye
+Zambia	Republic of Zambia	zambia|northern.?rhodesia	ZM	ZMB	894	894	251	191	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ZMB	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Zambia	288	zm
 Zanzibar	Zanzibar	zanz|.*tanzania:?zanzibar		EAZ					Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW																		1964	RoW							Other Africa	
-Zimbabwe	Republic of Zimbabwe	zimbabwe|^(?!.*northern).*rhodesia	ZW	ZWE	716	716	181	198	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ZWE	AFR	Rest of Southern Africa	SSA												1980	1980		RoW							Zimbabwe	265
+Zimbabwe	Republic of Zimbabwe	zimbabwe|^(?!.*northern).*rhodesia	ZW	ZWE	716	716	181	198	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ZWE	AFR	Rest of Southern Africa	SSA												1980	1980		RoW							Zimbabwe	265	zw


### PR DESCRIPTION
I've added a "ccTLD" field.

Values are mostly the same as ISO2 in lower case, but not in all cases. For example, the United Kingom ISO code is GB, but it's TLD is UK. This might help solving #92 in a better way.

[Wikipedia has lots of information.](https://en.wikipedia.org/wiki/Country_code_top-level_domain)

I haven't looked into writing tests. Let me know if I should.

----

I'm still having an issue with some TLDs where I get `float('nan')` instead of the TLD.

    >>> coco.convert('Jersey', to='ccTLD')
    nan
    >>> coco.convert('Jersey', to='ISO2')
    'JE'
    >>> coco.convert('Sweden', to='ccTLD')
    'se'

The TSV data for Jersey looks ok to me. Any ideas what could cause this?
