### PR TITLE
correct then-than

### DIFF
--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -584,7 +584,7 @@ class CountryConverter:
                         result_list.append(self.data.loc[ind_regex, to].values[0])
                     if len(result_list) > 1:
                         log.warning(
-                            "More then one regular expression "
+                            "More than one regular expression "
                             "match for {}".format(spec_name)
                         )
 


### PR DESCRIPTION
This doesn't really matter, but I keep seeing it for a project I'm on. It's technically 'than' here, rather than 'then'