### PR TITLE
Bug fix: pandas_convert

### DIFF
--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -720,10 +720,6 @@ class CountryConverter:
         if not isinstance(series, pd.Series):
             raise TypeError("Input must be a Pandas Series")
 
-        # if `src` and `to` are the same, return without changing anything.
-        if src == to:
-            return series
-
         # Get the unique values for mapping.
         s_unique = series.unique()
 

--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" country_converter - Classification converter for countries"""
+"""country_converter - Classification converter for countries"""
 
 import argparse
 import logging

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -1,5 +1,4 @@
-""" Testing the country_converter functionality
-"""
+"""Testing the country_converter functionality"""
 
 import collections
 import logging
@@ -807,11 +806,11 @@ def test_pandas_convert_options():
     # Check that the Series are equal
     assert_series_equal(convert_exclude_prefix, pandas_exclude_prefix)
 
+
 def test_pandas_convert_alignment_with_convert():
     """Test that the pandas_convert method is aligned with the convert method"""
 
-    mixed_type_series = pd.Series(
-        ["Germany", "DE", "United States", "NGA", "invalid"])
+    mixed_type_series = pd.Series(["Germany", "DE", "United States", "NGA", "invalid"])
 
     cc = coco.CountryConverter()
 
@@ -825,7 +824,6 @@ def test_pandas_convert_alignment_with_convert():
     # Check that the Series are equal
     assert_series_equal(pandas_convert, convert_series)
 
-
     # check alignment when setting non default options
     pandas_convert = cc.pandas_convert(mixed_type_series, to="ISO3", not_found="empty")
     convert = cc.convert(mixed_type_series, to="ISO3", not_found="empty")
@@ -834,17 +832,13 @@ def test_pandas_convert_alignment_with_convert():
     # Check that the Series are equal
     assert_series_equal(pandas_convert, convert_series)
 
-
-    #check alignment on edge case when scr and to are the same
+    # check alignment on edge case when scr and to are the same
     pandas_convert = cc.pandas_convert(mixed_type_series, to="name", src="name")
     convert = cc.convert(mixed_type_series, to="name", src="name")
     convert_series = pd.Series(convert, index=mixed_type_series.index)
 
     # Check that the Series are equal
     assert_series_equal(pandas_convert, convert_series)
-
-
-
 
 
 def test_CC41_output():

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -807,6 +807,45 @@ def test_pandas_convert_options():
     # Check that the Series are equal
     assert_series_equal(convert_exclude_prefix, pandas_exclude_prefix)
 
+def test_pandas_convert_alignment_with_convert():
+    """Test that the pandas_convert method is aligned with the convert method"""
+
+    mixed_type_series = pd.Series(
+        ["Germany", "DE", "United States", "NGA", "invalid"])
+
+    cc = coco.CountryConverter()
+
+    # convert using pandas convert
+    pandas_convert = cc.pandas_convert(mixed_type_series, to="ISO3")
+
+    # convert using convert, the make it into a series
+    convert = cc.convert(mixed_type_series, to="ISO3")
+    convert_series = pd.Series(convert, index=mixed_type_series.index)
+
+    # Check that the Series are equal
+    assert_series_equal(pandas_convert, convert_series)
+
+
+    # check alignment when setting non default options
+    pandas_convert = cc.pandas_convert(mixed_type_series, to="ISO3", not_found="empty")
+    convert = cc.convert(mixed_type_series, to="ISO3", not_found="empty")
+    convert_series = pd.Series(convert, index=mixed_type_series.index)
+
+    # Check that the Series are equal
+    assert_series_equal(pandas_convert, convert_series)
+
+
+    #check alignment on edge case when scr and to are the same
+    pandas_convert = cc.pandas_convert(mixed_type_series, to="name", src="name")
+    convert = cc.convert(mixed_type_series, to="name", src="name")
+    convert_series = pd.Series(convert, index=mixed_type_series.index)
+
+    # Check that the Series are equal
+    assert_series_equal(pandas_convert, convert_series)
+
+
+
+
 
 def test_CC41_output():
     cc = coco.CountryConverter()


### PR DESCRIPTION
This pull request includes updates to the `country_converter` module and its tests, focusing on improving functionality and test coverage. The most important change includes removing the exit condition in the `pandas_convert` method, preventing unexpected behaviour. A new test is added to ensure alignment between the `pandas_convert` and `convert` methods, and to catch edge cases including when `src` and `to` are set to the same value.

Improvements to functionality:

* [`country_converter/country_converter.py`](diffhunk://#diff-a1978f6c8537f210df63750f56dbd946ba69810749444407f3f3abc3b8f9a662L723-L726): Removed the exit condition in `pandas_convert` method that checked if `src` and `to` are the same.

Enhancements to test coverage:

* [`tests/test_functionality.py`](diffhunk://#diff-4b70684968cffefa61036b57c368846675178d8b18accab49662126d23ebe173R810-R843): Added a new test `test_pandas_convert_alignment_with_convert` to ensure the `pandas_convert` method is aligned with the `convert` method, including edge cases and non-default options.

Code style improvements:

* [`tests/test_functionality.py`](diffhunk://#diff-4b70684968cffefa61036b57c368846675178d8b18accab49662126d23ebe173L1-R1): Enforces black styling on edited files in accordance with the contribution guidelines